### PR TITLE
Feature MS 관리자가 코스 등록/삭제, 강사 등록, 정산, 라이브 강의 등록 요청을 승인 또는 반려

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,10 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,java,git,database,gradle,intellij+all
+
+# uploads 폴더 내의 모든 파일을 무시
+/uploads/**
+
+# 하지만 .gitkeep 파일들은 예외로 두어 폴더 구조를 유지
+!/uploads/.gitkeep
+!/uploads/**/.gitkeep

--- a/.postman/resources.yaml
+++ b/.postman/resources.yaml
@@ -1,0 +1,9 @@
+# Use this workspace to collaborate
+workspace:
+  id: 47aeb709-ba8e-439b-8308-0cf48e304e45
+
+# All resources in the `postman/` folder are automatically registered in Local View.
+# Point to additional files outside the `postman/` folder to register them individually. Example:
+#localResources:
+#  collections:
+#    - ../tests/E2E Test Collection/

--- a/postman/collections/New Collection/.resources/definition.yaml
+++ b/postman/collections/New Collection/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+name: New Collection

--- a/postman/collections/New Collection/.resources/definition.yaml
+++ b/postman/collections/New Collection/.resources/definition.yaml
@@ -1,2 +1,0 @@
-$kind: collection
-name: New Collection

--- a/postman/globals/workspace.globals.yaml
+++ b/postman/globals/workspace.globals.yaml
@@ -1,0 +1,2 @@
+name: Globals
+values: []

--- a/postman/globals/workspace.globals.yaml
+++ b/postman/globals/workspace.globals.yaml
@@ -1,2 +1,0 @@
-name: Globals
-values: []

--- a/src/main/java/com/wanted/naeil/domain/admin/dto/request/BlacklistRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/dto/request/BlacklistRequest.java
@@ -1,4 +1,14 @@
 package com.wanted.naeil.domain.admin.dto.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class BlacklistRequest {
+    Long userId;
+    String reason;
+
 }

--- a/src/main/java/com/wanted/naeil/domain/admin/dto/response/ApprovalResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/dto/response/ApprovalResponse.java
@@ -20,6 +20,17 @@ public class ApprovalResponse {
     private String thumbnail;
     private String categoryName;
     private String instuctorName;
+    private Long liveId;
+    private Long applicationId;
+    private String applicantName;
+    private String introduction;
+    private String career;
+    private String proofFileUrl;
+    private String faceImgUrl;
+    private String description;
+    private Integer maxCapacity;
+    private LocalDateTime startAt;
+
 
 
 }

--- a/src/main/java/com/wanted/naeil/domain/admin/dto/response/BlacklistResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/dto/response/BlacklistResponse.java
@@ -1,4 +1,13 @@
 package com.wanted.naeil.domain.admin.dto.response;
 
+import java.time.LocalDateTime;
+
 public class BlacklistResponse {
+
+    Long blacklistID;
+    Long userId;
+    String userName;
+    String reason;
+    String releaseReason;
+    LocalDateTime createdAt;
 }

--- a/src/main/java/com/wanted/naeil/domain/admin/entity/AdminApproval.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/entity/AdminApproval.java
@@ -7,17 +7,16 @@ import com.wanted.naeil.domain.user.entity.InstructorApplications;
 import com.wanted.naeil.domain.user.entity.User;
 import com.wanted.naeil.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
 
 @Entity
 @Table(name = "admin_approvals")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AdminApproval extends BaseTimeEntity {
 
     @Id
@@ -56,7 +55,6 @@ public class AdminApproval extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
-    @Builder.Default
     private ApprovalStatus status = ApprovalStatus.PENDING;
 
     @Column(name = "reject_reason", columnDefinition = "TEXT")
@@ -73,5 +71,30 @@ public class AdminApproval extends BaseTimeEntity {
         this.status = ApprovalStatus.REJECTED;
         this.admin = admin;
         this.rejectReason = rejectReason;
+    }
+
+    @Builder
+    public AdminApproval(Course course, ApprovalRequestType requestType) {
+        this.course = course;
+        this.requestType = requestType;
+        this.status = ApprovalStatus.PENDING;
+    }
+    @Builder
+    public AdminApproval(InstructorApplications applications) {
+        this.instructorApplications = applications;
+        this.requestType = ApprovalRequestType.INSTRUCTOR_REGISTER;
+        this.status = ApprovalStatus.PENDING;
+    }
+    @Builder
+    public AdminApproval(LiveLecture lecture) {
+        this.lecture = lecture;
+        this.requestType = ApprovalRequestType.LIVE_REGISTER;
+        this.status = ApprovalStatus.PENDING;
+    }
+    @Builder
+    public AdminApproval(Settlement settlement) {
+        this.settlement = settlement;
+        this.requestType = ApprovalRequestType.SETTLEMENT_REGISTER;
+        this.status = ApprovalStatus.PENDING;
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/admin/repository/BlacklistRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/repository/BlacklistRepository.java
@@ -1,4 +1,7 @@
 package com.wanted.naeil.domain.admin.repository;
 
-public class BlacklistRepository {
+import com.wanted.naeil.domain.admin.entity.BlacklistHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlacklistRepository extends JpaRepository<BlacklistHistory, Long> {
 }

--- a/src/main/java/com/wanted/naeil/domain/admin/service/AdminApprovalService.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/service/AdminApprovalService.java
@@ -6,12 +6,13 @@ import com.wanted.naeil.domain.admin.entity.ApprovalStatus;
 import com.wanted.naeil.domain.admin.entity.AdminApproval;
 import com.wanted.naeil.domain.admin.repository.AdminApprovalRepository;
 import com.wanted.naeil.domain.course.entity.Course;
-import com.wanted.naeil.domain.learning.repository.EnrollmentRepository;
 import com.wanted.naeil.domain.live.entity.LiveLecture;
 import com.wanted.naeil.domain.live.entity.LiveLectureStatus;
+import com.wanted.naeil.domain.live.repository.LiveLectureRepository;
 import com.wanted.naeil.domain.user.entity.InstructorApplications;
 import com.wanted.naeil.domain.user.entity.Role;
 import com.wanted.naeil.domain.user.entity.User;
+import com.wanted.naeil.domain.user.repository.InsturctorApplicationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor //service에서 Repository 쓰야하니까 필드선언
 public class AdminApprovalService {
     private final AdminApprovalRepository courseApprovalRepository;
+    private final InsturctorApplicationRepository insturctorApplicationRepository;
+    private final LiveLectureRepository liveLectureRepository;
 
     // 1. 승인 목록조회
     @Transactional
@@ -93,17 +96,20 @@ public class AdminApprovalService {
             case INSTRUCTOR_REGISTER -> {
                 approval.getInstructorApplications().approve();
                 approval.getInstructorApplications().getUser().changeRole(Role.INSTRUCTOR);
+                insturctorApplicationRepository.save(approval.getInstructorApplications());
             }
             case LIVE_REGISTER -> {
                 approval.getLecture().changeStatus(LiveLectureStatus.APPROVED);
+                liveLectureRepository.save(approval.getLecture());
             }
 
         }
+        courseApprovalRepository.save(approval);
     }
     // 3. 반려 처리
     @Transactional
     public  void reject(Long approvalId , User admin , String rejectReason) {
-        // 1) 반려건 찾아오기
+        // 1) 반려 건 찾아오기
         AdminApproval approval = courseApprovalRepository.findById(approvalId)
                 .orElseThrow(() -> new RuntimeException("반려 건을 찾을수 없습니다"));
         // 2) 반려 처리
@@ -114,11 +120,14 @@ public class AdminApprovalService {
             }
             case INSTRUCTOR_REGISTER -> {
                 approval.getInstructorApplications().reject(rejectReason);
+                insturctorApplicationRepository.save(approval.getInstructorApplications());
             }
             case LIVE_REGISTER -> {
                 approval.getLecture().changeStatus(LiveLectureStatus.REJECTED);
+                liveLectureRepository.save(approval.getLecture());
             }
         }
+        courseApprovalRepository.save(approval);
 
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/admin/service/AdminApprovalService.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/service/AdminApprovalService.java
@@ -3,11 +3,18 @@ package com.wanted.naeil.domain.admin.service;
 import com.wanted.naeil.domain.admin.dto.response.ApprovalResponse;
 import com.wanted.naeil.domain.admin.entity.ApprovalRequestType;
 import com.wanted.naeil.domain.admin.entity.ApprovalStatus;
-import com.wanted.naeil.domain.admin.entity.CourseApproval;
+import com.wanted.naeil.domain.admin.entity.AdminApproval;
 import com.wanted.naeil.domain.admin.repository.AdminApprovalRepository;
+import com.wanted.naeil.domain.course.entity.Course;
+import com.wanted.naeil.domain.learning.repository.EnrollmentRepository;
+import com.wanted.naeil.domain.live.entity.LiveLecture;
+import com.wanted.naeil.domain.live.entity.LiveLectureStatus;
+import com.wanted.naeil.domain.user.entity.InstructorApplications;
+import com.wanted.naeil.domain.user.entity.Role;
 import com.wanted.naeil.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,53 +23,102 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor //service에서 Repository 쓰야하니까 필드선언
 public class AdminApprovalService {
     private final AdminApprovalRepository courseApprovalRepository;
-    // @RequiredArgsConstructor 있으면 final 필드보고 원래
-    //public AdminCourseApprovalService(CourseApprovalRepository courseApprovalRepository) {
-    //    this.courseApprovalRepository = courseApprovalRepository;
-    // 이렇게 길게 써야하는걸 final + @RequiredArgsConstructor 이거써서 자동 생성
-    // 1. 목록조회
+
+    // 1. 승인 목록조회
+    @Transactional
     public List<ApprovalResponse> getApprovals(ApprovalRequestType type){
 
-        List<CourseApproval>approvals = courseApprovalRepository.findAllByRequestTypeAndStatus(type, ApprovalStatus.PENDING);
+        List<AdminApproval>approvals = courseApprovalRepository.findAllByRequestTypeAndStatus(type, ApprovalStatus.PENDING);
 
         return approvals.stream()
-                .map(approval -> ApprovalResponse.builder()
-                        .approvalId(approval.getApprovalId())
-                        .requestType(approval.getRequestType())
-                        .status(approval.getStatus())
-                        .createdAt(approval.getCreatedAt())
-                        .courseId(approval.getCourse().getId())
-                        .title(approval.getCourse().getTitle())
-                        .price(approval.getCourse().getPrice())
-                        .thumbnail(approval.getCourse().getThumbnail())
-                        .categoryName(approval.getCourse().getCategory().getName())
-                        .instuctorName(approval.getCourse().getInstructor().getName())
-                        .build())
+                .map(approval -> {
+                    ApprovalResponse.ApprovalResponseBuilder builder =
+                    ApprovalResponse.builder()
+                            .approvalId(approval.getApprovalId())
+                            .requestType(approval.getRequestType())
+                            .status(approval.getStatus())
+                            .createdAt(approval.getCreatedAt());
+                    switch (approval.getRequestType()) {
+                        case COURSE_REGISTER , COURSE_DELETE -> {
+                            Course course = approval.getCourse();
+                            builder.courseId(course.getId())
+                                    .title(course.getTitle())
+                                    .price(course.getPrice())
+                                    .thumbnail(course.getThumbnail())
+                                    .categoryName(course.getCategory().getName())
+                                    .instuctorName(course.getInstructor().getName());
+                        }
+                        case INSTRUCTOR_REGISTER -> {
+                            InstructorApplications applications =
+                                    approval.getInstructorApplications();
+                            builder.applicationId(applications.getId())
+                                    .applicantName(applications.getUser().getName())
+                                    .title(applications.getTitle())
+                                    .categoryName(applications.getCategory().getName())
+                                    .introduction(applications.getIntroduction())
+                                    .career(applications.getCareer())
+                                    .proofFileUrl(applications.getProofFileUrl())
+                                    .faceImgUrl(applications.getFaceImgUrl());
+                        }
+                        case LIVE_REGISTER -> {
+                            LiveLecture lecture = approval.getLecture();
+                            builder.liveId((lecture.getId()))
+                                    .title(lecture.getTitle())
+                                    .description(lecture.getDescription())
+                                    .maxCapacity(lecture.getMaxCapacity())
+                                    .startAt(lecture.getStartAt())
+                                    .instuctorName(lecture.getInstructor().getName());
+                        }
+                    }
+                    return builder.build();
+                })
                 .collect(Collectors.toList());
-    }
-
+        }
     // 2. 승인 처리
+    @Transactional
     public void approve(Long approvalId, User admin) {
         // 1) 승인건 찾아오기
-        CourseApproval approval = courseApprovalRepository.findById(approvalId)
+        AdminApproval approval = courseApprovalRepository.findById(approvalId)
                 .orElseThrow(() -> new RuntimeException("승인 건을 찾을수 없습니다"));
-        // .orElseThrow = 값이 없으면 예외 던지라는거여
         // 2) 승인 처리
-        approval.approve((admin));
-        // 3) 코스 활성화
-        approval.getCourse().activate();
-    }
+        approval.approve(admin);
+        // 3) type별 후속 처리
+        switch (approval.getRequestType()) {
+            case COURSE_REGISTER -> {
+                approval.getCourse().activate();
+            }
+            case  COURSE_DELETE -> {
+                approval.getCourse().deactivate();
+            }
+            case INSTRUCTOR_REGISTER -> {
+                approval.getInstructorApplications().approve();
+                approval.getInstructorApplications().getUser().changeRole(Role.INSTRUCTOR);
+            }
+            case LIVE_REGISTER -> {
+                approval.getLecture().changeStatus(LiveLectureStatus.APPROVED);
+            }
 
+        }
+    }
     // 3. 반려 처리
+    @Transactional
     public  void reject(Long approvalId , User admin , String rejectReason) {
         // 1) 반려건 찾아오기
-        CourseApproval approval =  courseApprovalRepository.findById(approvalId)
+        AdminApproval approval = courseApprovalRepository.findById(approvalId)
                 .orElseThrow(() -> new RuntimeException("반려 건을 찾을수 없습니다"));
         // 2) 반려 처리
-        approval.reject(admin , rejectReason);
+        approval.reject(admin, rejectReason);
 
+        switch (approval.getRequestType()) {
+            case COURSE_REGISTER, COURSE_DELETE -> {
+            }
+            case INSTRUCTOR_REGISTER -> {
+                approval.getInstructorApplications().reject(rejectReason);
+            }
+            case LIVE_REGISTER -> {
+                approval.getLecture().changeStatus(LiveLectureStatus.REJECTED);
+            }
+        }
 
     }
-
-
 }

--- a/src/main/java/com/wanted/naeil/domain/admin/service/AdminInstructorService.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/service/AdminInstructorService.java
@@ -1,4 +1,0 @@
-package com.wanted.naeil.domain.admin.service;
-
-public class AdminInstructorService {
-}

--- a/src/main/java/com/wanted/naeil/domain/admin/service/AdminLiveService.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/service/AdminLiveService.java
@@ -1,4 +1,0 @@
-package com.wanted.naeil.domain.admin.service;
-
-public class AdminLiveService {
-}

--- a/src/main/java/com/wanted/naeil/domain/admin/service/AdminUserService.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/service/AdminUserService.java
@@ -1,4 +1,11 @@
 package com.wanted.naeil.domain.admin.service;
 
+import com.wanted.naeil.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class AdminUserService {
+    private final UserRepository userRepository;
 }

--- a/src/main/java/com/wanted/naeil/domain/course/entity/Section.java
+++ b/src/main/java/com/wanted/naeil/domain/course/entity/Section.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalTime;
+
 @Entity
 @Table(name = "sections")
 @Getter
@@ -32,7 +34,7 @@ public class Section extends BaseTimeEntity {
     private String videoUrl;
 
     @Column(name = "play_time")
-    private int playTime;
+    private LocalTime playTime;
 
     @Column(name = "attachment_url", length = 500)
     private String attachmentUrl;
@@ -48,7 +50,7 @@ public class Section extends BaseTimeEntity {
     private SectionStatus status;
 
     @Builder
-    public Section(Course course, String title, String videoUrl, int playTime, String attachmentUrl, int sequence, Boolean isFree) {
+    public Section(Course course, String title, String videoUrl, LocalTime playTime, String attachmentUrl, int sequence, Boolean isFree) {
         this.course = course;
         this.title = title;
         this.videoUrl = videoUrl;

--- a/src/main/java/com/wanted/naeil/domain/live/repository/LiveLectureRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/live/repository/LiveLectureRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.naeil.domain.live.repository;
+
+import com.wanted.naeil.domain.live.entity.LiveLecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LiveLectureRepository extends JpaRepository<LiveLecture, Long> {
+}

--- a/src/main/java/com/wanted/naeil/domain/user/repository/InsturctorApplicationRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/user/repository/InsturctorApplicationRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.naeil.domain.user.repository;
+
+import com.wanted.naeil.domain.user.entity.InstructorApplications;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InsturctorApplicationRepository extends JpaRepository<InstructorApplications, Long> {
+}

--- a/src/test/java/com/wanted/naeil/ksm/NaeIlApplicationTests.java
+++ b/src/test/java/com/wanted/naeil/ksm/NaeIlApplicationTests.java
@@ -1,4 +1,4 @@
-package com.wanted.naeil;
+package com.wanted.naeil.ksm;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/test.http
+++ b/src/test/test.http
@@ -1,0 +1,11 @@
+### 코스 등록 승인 목록 조회
+GET http://localhost:8080/api/admin/course-approvals?type=COURSE_REGISTER
+### 코스 등록 승인
+PATCH http://localhost:8080/api/admin/course-approvals/3/approve
+### 코스 등록 반려
+PATCH http://localhost:8080/api/admin/course-approvals/3/reject
+Content-Type: application/json
+
+{
+  "rejectReason": "내용 부족"
+}


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
-관리자 페이지 승인/반려 처리 REST API 구현 및 Service 계층 비즈니스 로직 추가
-AdminApproval 엔티티 통합 및 타입별(코스/강사/정산/라이브) 승인 처리 로직 구현

## 💡 어떤 기능인가요?
- LMS 관리자가 코스 등록/삭제, 강사 등록, 정산, 라이브 강의 등록 요청을 승인 또는 반려할 수 있는 백엔드 API 구현
-
## ✨ 변경 사항 (Changes)
-AdminApprovalController 및 관련 엔드포인트 추가
-GET /api/admin/course-approvals?type={type} - 타입별 승인 대기 목록 조회
-PATCH /api/admin/course-approvals/{approvalId}/approve - 승인 처리
-PATCH /api/admin/course-approvals/{approvalId}/reject - 반려 처리
-AdminApprovalService 타입별 승인/반려 비즈니스 로직 구현
-기존 CourseApproval 엔티티를 AdminApproval로 통합 리팩토링
-ApprovalRequestType Enum 추가 (COURSE_REGISTER / COURSE_DELETE / LIVE_REGISTER / INSTRUCTOR_REGISTER / -SETTLEMENT_REGISTER)
-BlacklistRequest, RejectRequest, ApprovalResponse 등 DTO 추가
-DB 스키마 변경: admin_approvals 테이블 신규 생성, course_approvals 테이블 대체

## 📝 작업 상세 내용
- [ ] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 5개 타입별 승인 목록 조회 확인
- [x] 승인/반려 처리 각 케이스 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 현재 AdminApprovalController에서 로그인한 관리자 User 객체 자리에 임시로 null을 사용하고 있습니다. 세션/인증 구현 완료 후 실제 로그인 관리자 정보로 교체 필요합니다.

## ✅ 체크 리스트
- [x] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #43 