### PR TITLE
좋아요 기능 구현 / courseDetail.html 수정

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/community/controller/LikeController.java
+++ b/src/main/java/com/wanted/naeil/domain/community/controller/LikeController.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -34,7 +35,22 @@ public class LikeController {
         User loginUser = getLoginUser(authDetails);
         String redirectUrl = likeService.addLike(request, loginUser);
 
-        mv.setViewName("redirect: " + redirectUrl);
+        mv.setViewName("redirect:" + redirectUrl);
+        return mv;
+    }
+
+    // 좋아요 취소
+    @PostMapping("/likes/{likeId}/delete")
+    public ModelAndView deleteLike(@PathVariable Long likeId,
+                                   @AuthenticationPrincipal AuthDetails authDetails,
+                                   ModelAndView mv) {
+
+        log.info("[좋아요 취소] likeId: {}", likeId);
+
+        User loginUser = getLoginUser(authDetails);
+        String redirectUrl = likeService.deleteLike(likeId, loginUser);
+
+        mv.setViewName("redirect:" + redirectUrl);
         return mv;
     }
 

--- a/src/main/java/com/wanted/naeil/domain/community/controller/LikeController.java
+++ b/src/main/java/com/wanted/naeil/domain/community/controller/LikeController.java
@@ -1,0 +1,47 @@
+package com.wanted.naeil.domain.community.controller;
+
+import com.wanted.naeil.domain.community.dto.request.LikeCreateRequest;
+import com.wanted.naeil.domain.community.service.LikeService;
+import com.wanted.naeil.domain.user.entity.User;
+import com.wanted.naeil.domain.user.repository.UserRepository;
+import com.wanted.naeil.global.auth.model.dto.AuthDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.NoSuchElementException;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class LikeController {
+
+    private final LikeService likeService;
+    private final UserRepository userRepository;
+
+    // 좋아요 등록
+    @PostMapping("/likes")
+    public ModelAndView addLike(@ModelAttribute LikeCreateRequest request,
+                                @AuthenticationPrincipal AuthDetails authDetails,
+                                ModelAndView mv) {
+
+        log.info("[좋아요 등록] targetType: {}, targetId: {}", request.getTargetType(), request.getTargetId());
+
+        User loginUser = getLoginUser(authDetails);
+        String redirectUrl = likeService.addLike(request, loginUser);
+
+        mv.setViewName("redirect: " + redirectUrl);
+        return mv;
+    }
+
+    // 공통 메서드
+    private User getLoginUser(AuthDetails authDetails) {
+        if (authDetails == null) return null;
+        return userRepository.findByUsername(authDetails.getLoginUserDTO().getUsername())
+                .orElseThrow(() -> new NoSuchElementException("유저를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/community/dto/request/LikeCreateRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/community/dto/request/LikeCreateRequest.java
@@ -1,0 +1,15 @@
+package com.wanted.naeil.domain.community.dto.request;
+
+import com.wanted.naeil.domain.community.entity.enums.LikeTargetType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Setter
+public class LikeCreateRequest {
+
+    private LikeTargetType targetType;
+    private Long targetId;
+}

--- a/src/main/java/com/wanted/naeil/domain/community/repository/LikeRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/community/repository/LikeRepository.java
@@ -2,6 +2,7 @@ package com.wanted.naeil.domain.community.repository;
 
 import com.wanted.naeil.domain.community.entity.Like;
 import com.wanted.naeil.domain.community.entity.Post;
+import com.wanted.naeil.domain.course.entity.Course;
 import com.wanted.naeil.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,9 +12,11 @@ import java.util.Optional;
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
+    // 게시글 좋아요 단건 조회
     Optional<Like> findByUserAndPost(User user, Post post);
 
-    long countByPost(Post post);
+    // 강의 좋아요 단건 조회
+    Optional<Like> findByUserAndCourse(User user, Course course);
 
-    Optional<Like> findByLikeId(Long likeId);
+    long countByPost(Post post);
 }

--- a/src/main/java/com/wanted/naeil/domain/community/service/LikeService.java
+++ b/src/main/java/com/wanted/naeil/domain/community/service/LikeService.java
@@ -1,0 +1,68 @@
+package com.wanted.naeil.domain.community.service;
+
+import com.wanted.naeil.domain.community.dto.request.LikeCreateRequest;
+import com.wanted.naeil.domain.community.entity.Like;
+import com.wanted.naeil.domain.community.entity.Post;
+import com.wanted.naeil.domain.community.entity.enums.LikeTargetType;
+import com.wanted.naeil.domain.community.repository.LikeRepository;
+import com.wanted.naeil.domain.community.repository.PostRepository;
+import com.wanted.naeil.domain.course.entity.Course;
+import com.wanted.naeil.domain.course.repository.CourseRepository;
+import com.wanted.naeil.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
+    private final CourseRepository courseRepository;
+
+    // 좋아요 등록
+    @Transactional
+    public String addLike(LikeCreateRequest request, User loginUser) {
+
+        // 게시글
+        if (request.getTargetType() == LikeTargetType.POST) {
+            Post post = postRepository.findById(request.getTargetId())
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 게시글입니다."));
+
+            if (likeRepository.findByUserAndPost(loginUser, post).isPresent()) {
+                throw new IllegalStateException("이미 좋아요를 등록했습니다.");
+            }
+
+            likeRepository.save(Like.builder()
+                    .user(loginUser)
+                    .targetType(LikeTargetType.POST)
+                    .post(post)
+                    .build());
+            return "/community/" + post.getCategory().name().toLowerCase() + "/" + post.getPostId();
+        }
+
+        // 강의
+        else if (request.getTargetType() == LikeTargetType.COURSE) {
+            Course course = courseRepository.findById(request.getTargetId())
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 강의입니다."));
+
+            if (likeRepository.findByUserAndCourse(loginUser, course).isPresent()) {
+                throw new IllegalStateException("이미 좋아요를 등록했습니다.");
+            }
+
+            likeRepository.save(Like.builder()
+                    .user(loginUser)
+                    .targetType(LikeTargetType.COURSE)
+                    .course(course)
+                    .build());
+            return "/courses/" + course.getId();
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 좋아요 대상입니다.");
+        }
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/community/service/LikeService.java
+++ b/src/main/java/com/wanted/naeil/domain/community/service/LikeService.java
@@ -11,6 +11,7 @@ import com.wanted.naeil.domain.course.repository.CourseRepository;
 import com.wanted.naeil.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,5 +65,24 @@ public class LikeService {
         } else {
             throw new IllegalArgumentException("지원하지 않는 좋아요 대상입니다.");
         }
+    }
+
+    // 좋아요 취소
+    @Transactional
+    public String deleteLike(Long likeId, User loginUser) {
+
+        Like like = likeRepository.findById(likeId)
+                .orElseThrow(() -> new NoSuchElementException("해당 좋아요를 찾을 수 없습니다."));
+
+        if (!like.getUser().getId().equals(loginUser.getId())) {
+            throw new AccessDeniedException("해당 기능에 대한 접속 권한이 없습니다.");
+        }
+
+        String redirectUrl = like.getTargetType() == LikeTargetType.POST
+                ? "/community/" + like.getPost().getCategory().name().toLowerCase() + "/" + like.getPost().getPostId()
+                : "/courses/" + like.getCourse().getId();
+
+        likeRepository.delete(like);
+        return redirectUrl;
     }
 }

--- a/src/main/resources/templates/community/QnADetail.html
+++ b/src/main/resources/templates/community/QnADetail.html
@@ -100,12 +100,23 @@
         </div>
 
         <div class="flex items-center gap-3 pt-6 border-t-2 border-gray-200">
-          <form th:action="@{/likes}" method="post">
+          <!-- 좋아요 등록 -->
+          <form th:if="${!post.isLiked}" th:action="@{/likes}" method="post">
             <input type="hidden" name="targetType" value="POST">
             <input type="hidden" name="targetId" th:value="${post.postId}">
             <button type="submit"
-                    th:class="${post.isLiked} ? 'inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold bg-gradient-to-r from-red-500 to-pink-500 text-white shadow-lg' : 'inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold border-2 border-gray-300 text-gray-700 hover:border-red-500 hover:text-red-500'">
-              <i th:class="${post.isLiked} ? 'fa-solid fa-heart' : 'fa-regular fa-heart'" class="text-lg"></i>
+                    class="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold border-2 border-gray-300 text-gray-700 hover:border-red-500 hover:text-red-500">
+              <i class="fa-regular fa-heart text-lg"></i>
+              <span th:text="${post.likeCount}">0</span>
+            </button>
+          </form>
+          <!-- 좋아요 취소 -->
+          <form th:if="${post.isLiked}"
+                th:action="@{/likes/{likeId}/delete(likeId=${post.likeId})}" method="post"
+                onsubmit="return confirm('좋아요를 취소하시겠습니까?')">
+            <button type="submit"
+                    class="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold bg-gradient-to-r from-red-500 to-pink-500 text-white shadow-lg">
+              <i class="fa-solid fa-heart text-lg"></i>
               <span th:text="${post.likeCount}">0</span>
             </button>
           </form>

--- a/src/main/resources/templates/community/freeBoardDetail.html
+++ b/src/main/resources/templates/community/freeBoardDetail.html
@@ -79,12 +79,23 @@
         </div>
 
         <div class="flex items-center gap-3 pt-6 border-t-2 border-gray-200">
-          <form th:action="@{/likes}" method="post">
+          <!-- 좋아요 등록 -->
+          <form th:if="${!post.isLiked}" th:action="@{/likes}" method="post">
             <input type="hidden" name="targetType" value="POST">
             <input type="hidden" name="targetId" th:value="${post.postId}">
             <button type="submit"
-                    th:class="${post.isLiked} ? 'inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold bg-gradient-to-r from-red-500 to-pink-500 text-white shadow-lg' : 'inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold border-2 border-gray-300 text-gray-700 hover:border-red-500 hover:text-red-500'">
-              <i th:class="${post.isLiked} ? 'fa-solid fa-heart' : 'fa-regular fa-heart'" class="text-lg"></i>
+                    class="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold border-2 border-gray-300 text-gray-700 hover:border-red-500 hover:text-red-500">
+              <i class="fa-regular fa-heart text-lg"></i>
+              <span th:text="${post.likeCount}">0</span>
+            </button>
+          </form>
+          <!-- 좋아요 취소 -->
+          <form th:if="${post.isLiked}"
+                th:action="@{/likes/{likeId}/delete(likeId=${post.likeId})}" method="post"
+                onsubmit="return confirm('좋아요를 취소하시겠습니까?')">
+            <button type="submit"
+                    class="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-bold bg-gradient-to-r from-red-500 to-pink-500 text-white shadow-lg">
+              <i class="fa-solid fa-heart text-lg"></i>
               <span th:text="${post.likeCount}">0</span>
             </button>
           </form>

--- a/src/main/resources/templates/course/courseDetail.html
+++ b/src/main/resources/templates/course/courseDetail.html
@@ -68,7 +68,9 @@
           <div class="flex items-center gap-3 shrink-0">
             <span class="font-semibold text-gray-700"
                   th:text="${#numbers.formatInteger(course.likeCount, 0, 'COMMA')}">0</span>
-            <form th:action="@{/course/{id}/like(id=${course.courseId})}" method="post">
+            <form th:action="@{/likes}" method="post">
+              <input type="hidden" name="targetType" value="COURSE">
+              <input type="hidden" name="targetId" th:value="${course.courseId}">
               <button type="submit"
                       class="w-9 h-9 rounded-full flex items-center justify-center text-gray-400 hover:text-red-500 hover:bg-red-50 transition">
                 <i class="fa-regular fa-heart"></i>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 게시글 및 강의 좋아요 등록/취소 기능 구현
- 좋아요는 `targetType`(POST/COURSE)으로 구분하여 하나의 API로 처리
- 좋아요 취소는 Hard Delete 방식으로 처리 (Soft Delete 제외 이유: 중복 좋아요 방지 및 @UniqueConstraint 충돌 방지)

## 💡 어떤 기능인가요?
- 커뮤니티 게시글 상세 페이지에서 좋아요를 등록/취소 가능
- 강의 상세 페이지에서 좋아요를 등록/취소 가능
- 상세 조회 시 좋아요 여부(`isLiked`)와 `likeId`를 함께 반환

## ✨ 변경 사항 (Changes)
- `LikeController` 신규 생성 - 등록(`POST /likes`), 취소(`POST /likes/{likeId}/delete`) 엔드포인트 추가
- `LikeService` 신규 생성 - `addLike()`, `deleteLike()` 구현, switch로 targetType 분기 처리
- `LikeCreateRequest` DTO 신규 생성
- `LikeRepository` - 중복 메서드 `findByLikeId()` 제거, `findByUserAndCourse()` 추가
- `SecurityConfig` - `/community/**` permitAll() 추가 (비회원 목록/상세 조회 가능)
- `courseDetail.html` - 좋아요 form action URL 수정 (`/course/{id}/like` → `/likes`), targetType/targetId hidden input 추가
- **DB 스키마 변경:** 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [x] 버그 수정
- [ ] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 로컬 환경 브라우저를 통한 게시글 좋아요 등록 및 DB 반영 확인
- [x] 로컬 환경 브라우저를 통한 게시글 좋아요 취소 및 DB 반영 확인
- [x] 중복 좋아요 시 409 에러 처리 확인
- [x] 강의 좋아요 등록 및 DB 반영 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 좋아요 취소를 Soft Delete가 아닌 Hard Delete로 구현했습니다.
- 좋아요 취소 URL은 API 명세서의 `DELETE /likes/{likeId}` 대신 HiddenHttpMethodFilter 이슈로 `POST /likes/{likeId}/delete` 방식으로 통일했습니다.
- 강의 좋아요의 isLiked 분기 처리를 위해 CourseDetailsResponse에 아래 두 필드 추가가 필요합니다.  !!!정수 선배 확인 부탁드려요!!! (괜찮으시면 제가 수정해도 됩니다.)
  - isLiked (boolean) : 현재 로그인한 유저가 해당 강의에 좋아요를 눌렀는지 여부
  - likeId (Long) : 좋아요 취소 시 필요한 좋아요 PK (좋아요 안 눌렀으면 null)
  - 강의 상세 조회 Service에서 LikeRepository.findByUserAndCourse(loginUser, course)로 조회 후 넣어주면 돼요. PostService.getPost()와 동일한 패턴이에요!
  
## 📎 관련 이슈 (Related Issues)
- Closes #128 