### PR TITLE
내 정보 수정, 회원 탈퇴 기능 추가 및 강사 헤더 대시보드 드롭다운 수정

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/wanted/naeil/domain/user/controller/MyPageController.java
@@ -1,0 +1,131 @@
+package com.wanted.naeil.domain.user.controller;
+
+import com.wanted.naeil.domain.user.dto.request.UpdateNicknameRequest;
+import com.wanted.naeil.domain.user.dto.request.UpdatePasswordRequest;
+import com.wanted.naeil.domain.user.dto.request.UpdateProfileImgRequest;
+import com.wanted.naeil.domain.user.dto.request.WithdrawRequest;
+import com.wanted.naeil.domain.user.dto.response.AccountSettingResponse;
+import com.wanted.naeil.domain.user.service.MemberService;
+import com.wanted.naeil.global.auth.model.dto.AuthDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public ModelAndView myPage(@AuthenticationPrincipal AuthDetails authDetails, ModelAndView mv) {
+        AccountSettingResponse myPage = memberService.getMyPage(authDetails.getUsername());
+        mv.addObject("myPage", myPage);
+        mv.setViewName("mypage/accountSettings");
+        return mv;
+    }
+
+    @PostMapping("/me/profile-image")
+    public String updateProfileImg(@AuthenticationPrincipal AuthDetails authDetails,
+                                   @ModelAttribute UpdateProfileImgRequest request) {
+        memberService.updateProfileImg(authDetails.getUsername(), request);
+        return "redirect:/user/me";
+    }
+
+    @PostMapping("/me/profile-image/delete")
+    public String deleteProfileImg(@AuthenticationPrincipal AuthDetails authDetails) {
+        memberService.deleteProfileImg(authDetails.getUsername());
+        return "redirect:/user/me";
+    }
+
+    @PostMapping("/me/nickname")
+    public String updateNickname(@AuthenticationPrincipal AuthDetails authDetails,
+                                 @ModelAttribute UpdateNicknameRequest request,
+                                 RedirectAttributes redirectAttributes) {
+        try {
+            memberService.updateNickname(authDetails.getUsername(), request);
+            redirectAttributes.addFlashAttribute("successMessage", "닉네임이 변경되었습니다.");
+        } catch (DuplicateKeyException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/user/me";
+    }
+
+
+    // 비밀번호 변경(완료 시 세션 만료)
+    @PostMapping("/me/password")
+    public String updatePassword(@AuthenticationPrincipal AuthDetails authDetails,
+                                 @ModelAttribute UpdatePasswordRequest request,
+                                 HttpServletRequest httpRequest,
+                                 HttpServletResponse httpResponse,
+                                 RedirectAttributes redirectAttributes) {
+        try {
+            memberService.updatePassword(authDetails.getUsername(), request);
+
+            // Spring Security의 공식 로그아웃 핸들러 사용
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null) {
+                new SecurityContextLogoutHandler().logout(httpRequest, httpResponse, auth);
+            }
+
+            redirectAttributes.addFlashAttribute("message", "비밀번호가 변경되었습니다. 다시 로그인해 주세요.");
+            return "redirect:/auth/login";
+
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/user/me";
+        }
+    }
+
+    @PostMapping("/me/email")
+    public String updateEmail(@AuthenticationPrincipal AuthDetails authDetails,
+                              @ModelAttribute UpdateEmailRequest request,
+                              RedirectAttributes redirectAttributes) {
+        try {
+            memberService.updateEmail(authDetails.getUsername(), request);
+            redirectAttributes.addFlashAttribute("successMessage", "이메일이 변경되었습니다.");
+        } catch (DuplicateKeyException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/user/me";
+    }
+
+    // 회원탈퇴
+    @PostMapping("/me/withdraw")
+    public String withdraw(@AuthenticationPrincipal AuthDetails authDetails,
+                           @ModelAttribute WithdrawRequest request,
+                           HttpServletRequest httpRequest,
+                           HttpServletResponse httpResponse,
+                           RedirectAttributes redirectAttributes) {
+        try {
+            // 1. DB 상의 상태 변경 (Soft Delete)
+            memberService.withdraw(authDetails.getUsername(), request);
+
+            // 2. 실제 로그아웃 처리 (세션 및 시큐리티 컨텍스트 클리어)
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null) {
+                new SecurityContextLogoutHandler().logout(httpRequest, httpResponse, auth);
+            }
+
+            redirectAttributes.addFlashAttribute("message", "탈퇴가 완료되었습니다. 그동안 이용해주셔서 감사합니다.");
+            return "redirect:/"; // 메인으로 리다이렉트
+
+        } catch (IllegalArgumentException e) {
+            // 비밀번호가 틀린 경우 등
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/user/me"; // 마이페이지(혹은 설정페이지)로 복귀
+        }
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/user/controller/UpdateEmailRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/user/controller/UpdateEmailRequest.java
@@ -1,0 +1,12 @@
+package com.wanted.naeil.domain.user.controller;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateEmailRequest {
+    private String email;
+}

--- a/src/main/java/com/wanted/naeil/domain/user/controller/UserController.java
+++ b/src/main/java/com/wanted/naeil/domain/user/controller/UserController.java
@@ -104,4 +104,6 @@ public class UserController {
     }
 
 
+
+
 }

--- a/src/main/java/com/wanted/naeil/domain/user/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/user/dto/request/UpdateNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.wanted.naeil.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateNicknameRequest {
+    private String nickname;
+}

--- a/src/main/java/com/wanted/naeil/domain/user/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/user/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,14 @@
+package com.wanted.naeil.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdatePasswordRequest {
+    private String currentPassword;
+    private String newPassword;
+    private String confirmPassword;
+}

--- a/src/main/java/com/wanted/naeil/domain/user/dto/request/UpdateProfileImgRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/user/dto/request/UpdateProfileImgRequest.java
@@ -1,0 +1,13 @@
+package com.wanted.naeil.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateProfileImgRequest {
+    private MultipartFile profileImg;
+}

--- a/src/main/java/com/wanted/naeil/domain/user/dto/request/WithdrawRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/user/dto/request/WithdrawRequest.java
@@ -1,0 +1,12 @@
+package com.wanted.naeil.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class WithdrawRequest {
+    private String password;
+}

--- a/src/main/java/com/wanted/naeil/domain/user/dto/response/AccountSettingResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/user/dto/response/AccountSettingResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.naeil.domain.user.dto.response;
+
+import com.wanted.naeil.domain.user.entity.enums.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AccountSettingResponse {
+    private String username;
+    private String name;
+    private String nickname;
+    private String email;
+    private String phone;
+    private String profileImg;
+    private Role role;
+}

--- a/src/main/java/com/wanted/naeil/domain/user/entity/User.java
+++ b/src/main/java/com/wanted/naeil/domain/user/entity/User.java
@@ -136,6 +136,26 @@ public class User extends BaseTimeEntity {
         }
     }
 
+    // 프로필 업로드 승재
+    public void updateProfileImg(String profileImg) {
+        this.profileImg = profileImg;
+    }
+
+    // 닉네임 변경
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    // 비밀번호 변경
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    // 이메일 변경
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
 
 }
 

--- a/src/main/java/com/wanted/naeil/domain/user/service/MemberService.java
+++ b/src/main/java/com/wanted/naeil/domain/user/service/MemberService.java
@@ -3,12 +3,12 @@ package com.wanted.naeil.domain.user.service;
 
 import com.wanted.naeil.domain.payment.entity.Credit;
 import com.wanted.naeil.domain.payment.repository.CreditRepository;
-import com.wanted.naeil.domain.user.dto.request.FindIdRequest;
-import com.wanted.naeil.domain.user.dto.request.FindPasswordRequest;
+import com.wanted.naeil.domain.user.controller.UpdateEmailRequest;
+import com.wanted.naeil.domain.user.dto.request.*;
 import com.wanted.naeil.domain.user.dto.response.FindIdResponse;
 import com.wanted.naeil.domain.user.dto.response.FindPasswordResponse;
 import com.wanted.naeil.domain.user.dto.response.LoginUserDTO;
-import com.wanted.naeil.domain.user.dto.request.SignupDTO;
+import com.wanted.naeil.domain.user.dto.response.AccountSettingResponse;
 import com.wanted.naeil.domain.user.entity.User;
 import com.wanted.naeil.domain.user.repository.UserRepository;
 import com.wanted.naeil.global.util.file.LocalFileService;
@@ -157,6 +157,93 @@ private final LocalFileService localFileService;
         return FindPasswordResponse.builder()
                 .tempPassword(tempPassword)
                 .build();
+    }
+
+    // 마이 페이지 조회
+    public AccountSettingResponse getMyPage(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        return AccountSettingResponse.builder()
+                .username(user.getUsername())
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .profileImg(user.getProfileImg())
+                .role(user.getRole())
+                .build();
+    }
+
+    // 프로필 이미지 업로드
+    @Transactional
+    public void updateProfileImg(String username, UpdateProfileImgRequest request) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        validateProfileImg(request.getProfileImg());
+        String profileImgPath = localFileService.uploadSingleFile(request.getProfileImg(), "profiles");
+        user.updateProfileImg(profileImgPath);
+    }
+
+
+    // 프로필 이미지 삭제
+    @Transactional
+    public void deleteProfileImg(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        if (user.getProfileImg() != null) {
+            localFileService.deleteFile(user.getProfileImg());
+        }
+        user.updateProfileImg(null);
+    }
+
+    // 닉네임 변경
+    @Transactional
+    public void updateNickname(String username, UpdateNicknameRequest request) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new DuplicateKeyException("이미 사용 중인 닉네임입니다.");
+        }
+        user.updateNickname(request.getNickname());
+    }
+
+    // 비밀번호 변경
+    @Transactional
+    public void updatePassword(String username, UpdatePasswordRequest request) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        if (!encoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+        if (!request.getNewPassword().equals(request.getConfirmPassword())) {
+            throw new IllegalArgumentException("새 비밀번호가 일치하지 않습니다.");
+        }
+        user.updatePassword(encoder.encode(request.getNewPassword()));
+    }
+
+    // 이메일 변경
+    @Transactional
+    public void updateEmail(String username, UpdateEmailRequest request) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateKeyException("이미 사용 중인 이메일입니다.");
+        }
+        user.updateEmail(request.getEmail());
+    }
+
+    @Transactional
+    public void withdraw(String username, WithdrawRequest request) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        // 1. 비밀번호 검증
+        if (!encoder.matches(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 2. status를 INACTIVE로 변경
+        user.deactivate();
     }
 
 

--- a/src/main/java/com/wanted/naeil/global/common/controller/DashboardController.java
+++ b/src/main/java/com/wanted/naeil/global/common/controller/DashboardController.java
@@ -48,4 +48,6 @@ public class DashboardController {
     public String guestDashboard() {
         return "dashboard/guestDashboard";
     }
+
+
 }

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -37,6 +37,11 @@
         <p class="text-sm font-bold text-red-600">아이디 또는 비밀번호가 올바르지 않습니다.</p>
     </div>
 
+    <!-- 비밀번호 변경 성공 메시지 -->
+    <div th:if="${message}" class="mb-4 p-4 bg-green-50 border-2 border-green-200 rounded-xl">
+        <p class="text-sm font-bold text-green-600" th:text="${message}"></p>
+    </div>
+
     <!-- Login Form -->
     <div class="bg-white border-2 border-gray-200 rounded-2xl p-8 shadow-xl mb-6">
         <h2 class="text-3xl font-black text-gray-900 mb-2">로그인</h2>
@@ -48,6 +53,8 @@
                 <div class="relative">
                     <i class="fa-solid fa-user absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"></i>
                     <input type="text" name="user" placeholder="아이디를 입력하세요"
+                           autofocus
+                           autocomplete="username"
                            class="w-full pl-12 pr-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-600 focus:outline-none transition-colors font-medium"/>
                 </div>
             </div>
@@ -57,6 +64,7 @@
                 <div class="relative">
                     <i class="fa-solid fa-lock absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"></i>
                     <input type="password" name="pass" placeholder="••••••••"
+                           autocomplete="current-password"
                            class="w-full pl-12 pr-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-600 focus:outline-none transition-colors font-medium"/>
                 </div>
             </div>
@@ -87,6 +95,13 @@
         </div>
     </div>
 </div>
-
+<script>
+    document.getElementById('loginForm').addEventListener('submit', function() {
+        const btn = document.getElementById('loginBtn');
+        btn.disabled = true;
+        btn.innerHTML = '<i class="fa-solid fa-circle-notch animate-spin"></i> 로그인 중...';
+        btn.classList.add('opacity-70', 'cursor-not-allowed');
+    });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/dashboard/instructorDashboard.html
+++ b/src/main/resources/templates/dashboard/instructorDashboard.html
@@ -221,15 +221,15 @@
                 </div>
 
                 <div class="flex gap-2 items-center flex-shrink-0">
-                    <a th:href="@{/instructor/course/{id}(id=${course.courseId})}"
-                       href="/instructor/course/1"
+                    <a th:href="@{/course/{id}(id=${course.courseId})}"
+                       href="/course/1"
                        class="w-11 h-11 inline-flex items-center justify-center border-2 border-blue-300 text-blue-600 rounded-xl font-bold hover:bg-blue-50 hover:border-blue-600 transition-all"
                        title="조회">
                         <i data-lucide="eye" class="w-5 h-5"></i>
                     </a>
 
-                    <a th:href="@{/instructor/course/edit/{id}(id=${course.courseId})}"
-                       href="/instructor/course/edit/1"
+                    <a th:href="@{/instructor/course/{id}/edit(id=${course.courseId})}"
+                       href="/instructor/course/1/edit"
                        class="w-11 h-11 inline-flex items-center justify-center border-2 border-green-300 text-green-600 rounded-xl font-bold hover:bg-green-50 hover:border-green-600 transition-all"
                        title="수정">
                         <i data-lucide="pencil" class="w-5 h-5"></i>
@@ -339,6 +339,19 @@
 
 <script>
     lucide.createIcons();
+    function toggleInstructorProfileDropdown() {
+        const el = document.getElementById('instructorProfileDropdown');
+        if (el) {
+            el.style.display = el.style.display === 'none' ? 'block' : 'none';
+        }
+    }
+    document.addEventListener('click', function(e) {
+        const wrapper = document.getElementById('instructorProfileDropdownWrapper');
+        const dropdown = document.getElementById('instructorProfileDropdown');
+        if (wrapper && dropdown && !wrapper.contains(e.target)) {
+            dropdown.style.display = 'none';
+        }
+    });
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/dashboard/userDashboard.html
+++ b/src/main/resources/templates/dashboard/userDashboard.html
@@ -126,7 +126,7 @@
                                 <i class="fa-solid fa-video text-gray-600"></i>
                                 <span class="text-sm font-medium text-gray-900">내 강의</span>
                             </a>
-                            <a th:href="@{/account-settings}" href="/account-settings"
+                            <a th:href="@{/user/me}" href="/user/me"
                                class="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors">
                                 <i class="fa-solid fa-gear text-gray-600"></i>
                                 <span class="text-sm font-medium text-gray-900">계정 설정</span>

--- a/src/main/resources/templates/fragments/instructorHeader.html
+++ b/src/main/resources/templates/fragments/instructorHeader.html
@@ -69,7 +69,7 @@
             <a th:href="@{/auth/logout}"
                href="/auth/logout"
                class="hidden lg:inline-flex items-center gap-2 px-3 py-2 text-gray-700 font-bold hover:text-red-600 transition-colors text-sm">
-            <i class="fa-solid fa-arrow-right-from-bracket text-base"></i>
+                <i class="fa-solid fa-arrow-right-from-bracket text-base"></i>
                 <span>로그아웃</span>
             </a>
 
@@ -90,10 +90,29 @@
                 <i class="fa-regular fa-paper-plane text-lg"></i>
             </button>
 
-            <button type="button"
-                    class="w-11 h-11 bg-gradient-to-br from-green-500 to-blue-500 text-white rounded-xl flex items-center justify-center shadow-md">
-                <span class="font-black text-sm">{ }</span>
-            </button>
+            <div class="relative" id="instructorProfileDropdownWrapper">
+                <button type="button"
+                        onclick="toggleInstructorProfileDropdown()"
+                        class="w-11 h-11 bg-gradient-to-br from-green-500 to-blue-500 text-white rounded-xl flex items-center justify-center shadow-md">
+                    <span class="font-black text-sm">{ }</span>
+                </button>
+                <div id="instructorProfileDropdown"
+                     style="display:none;"
+                     class="absolute right-0 mt-2 w-56 bg-white border-2 border-gray-200 rounded-xl shadow-xl z-50">
+                    <div class="py-2">
+                        <a th:href="@{/instructor/course-management}" href="/instructor/course-management"
+                           class="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors">
+                            <i class="fa-solid fa-video text-gray-600"></i>
+                            <span class="text-sm font-medium text-gray-900">내 강의 관리</span>
+                        </a>
+                        <a th:href="@{/user/me}" href="/user/me"
+                           class="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors">
+                            <i class="fa-solid fa-gear text-gray-600"></i>
+                            <span class="text-sm font-medium text-gray-900">계정 설정</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/src/main/resources/templates/mypage/accountSettings.html
+++ b/src/main/resources/templates/mypage/accountSettings.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>계정 설정 | Nae-Il</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
+    <style>
+        .notice-dropdown { display: none; }
+        .notice-dropdown.open { display: block; }
+        .profile-dropdown { display: none; }
+        .profile-dropdown.open { display: block; }
+    </style>
+</head>
+<body class="bg-gray-50">
+
+<!-- 강사 헤더 -->
+<th:block th:if="${myPage.role.name() == 'INSTRUCTOR'}">
+    <div th:replace="~{fragments/instructorHeader :: instructorHeader}"></div>
+</th:block>
+
+<!-- 회원/구독자 헤더 -->
+<header th:unless="${myPage.role.name() == 'INSTRUCTOR'}"
+        class="border-b border-gray-200 bg-white/80 backdrop-blur-sm sticky top-0 z-50 shadow-sm">
+    <div class="max-w-7xl mx-auto px-6 py-4">
+        <div class="flex items-center justify-between">
+
+            <!-- Logo -->
+            <a th:href="@{/}" href="/" class="flex items-center gap-3 group">
+                <div class="w-10 h-10 bg-gradient-to-br from-blue-600 to-green-600 rounded-xl flex items-center justify-center shadow-lg">
+                    <i class="fa-solid fa-terminal text-white text-sm"></i>
+                </div>
+                <div>
+                    <h1 class="text-xl font-bold text-gray-900 tracking-tight">
+                        내일 <span class="text-gray-500 font-normal">Nae-il</span>
+                    </h1>
+                    <p class="text-[10px] font-semibold text-gray-500 tracking-wide">내일의 일, My Work</p>
+                </div>
+            </a>
+
+            <!-- Nav -->
+            <nav class="flex items-center gap-1 flex-nowrap">
+                <a th:href="@{/courses}" href="/courses" class="flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-gray-600 hover:bg-gray-50 transition-all whitespace-nowrap">
+                    <i class="fa-solid fa-book-open w-4 h-4"></i>
+                    <span class="text-xs font-medium">전체 강의</span>
+                </a>
+                <a th:href="@{/live}" href="/live" class="flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-gray-600 hover:bg-gray-50 transition-all whitespace-nowrap">
+                    <i class="fa-solid fa-calendar w-4 h-4"></i>
+                    <span class="text-xs font-medium">실시간 강의</span>
+                </a>
+                <a th:href="@{/my-courses}" href="/my-courses" class="flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-gray-600 hover:bg-gray-50 transition-all whitespace-nowrap">
+                    <i class="fa-solid fa-video w-4 h-4"></i>
+                    <span class="text-xs font-medium">내 강의</span>
+                </a>
+                <a th:href="@{/community/qna}" href="/community/qna" class="flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-gray-600 hover:bg-gray-50 transition-all whitespace-nowrap">
+                    <i class="fa-solid fa-comment w-4 h-4"></i>
+                    <span class="text-xs font-medium">커뮤니티</span>
+                </a>
+                <a th:href="@{/cart}" href="/cart" class="flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-gray-600 hover:bg-gray-50 transition-all whitespace-nowrap">
+                    <i class="fa-solid fa-cart-shopping w-4 h-4"></i>
+                    <span class="text-xs font-medium">장바구니</span>
+                </a>
+                <a th:href="@{/credit}" href="/credit" class="flex items-center gap-1.5 px-2.5 py-2 rounded-lg text-gray-600 hover:bg-gray-50 transition-all whitespace-nowrap">
+                    <i class="fa-solid fa-wallet w-4 h-4"></i>
+                    <span class="text-xs font-medium">크레딧</span>
+                </a>
+            </nav>
+
+            <!-- Right -->
+            <div class="flex items-center gap-4">
+                <a th:href="@{/auth/logout}" href="/auth/logout"
+                   class="flex items-center gap-2 px-4 py-2 rounded-xl hover:bg-red-50 transition-all group">
+                    <i class="fa-solid fa-right-from-bracket text-gray-600 group-hover:text-red-600 text-sm"></i>
+                    <span class="font-medium text-gray-700 group-hover:text-red-600 text-sm">로그아웃</span>
+                </a>
+                <div class="text-right">
+                    <p class="text-sm font-medium text-gray-900" th:text="${myPage.name}">사용자</p>
+                    <p class="text-xs font-mono text-gray-500" th:text="${myPage.email}">email</p>
+                </div>
+                <div class="relative" id="noticeDropdownWrapper">
+                    <button onclick="toggleNoticeDropdown()"
+                            class="w-10 h-10 rounded-lg bg-gradient-to-br from-orange-500 to-red-500 flex items-center justify-center shadow-md hover:shadow-lg transition-shadow cursor-pointer">
+                        <i class="fa-solid fa-bullhorn text-white text-sm"></i>
+                    </button>
+                    <div id="noticeDropdown" class="notice-dropdown absolute right-0 mt-2 w-48 bg-white border-2 border-gray-200 rounded-xl shadow-xl z-50">
+                        <div class="py-2">
+                            <a href="/notice" class="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors">
+                                <i class="fa-solid fa-bullhorn text-gray-600"></i>
+                                <span class="text-sm font-medium text-gray-900">공지사항</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="relative" id="profileDropdownWrapper">
+                    <button onclick="toggleProfileDropdown()"
+                            class="w-10 h-10 rounded-lg bg-gradient-to-br from-blue-500 to-green-500 flex items-center justify-center shadow-md hover:shadow-lg transition-shadow cursor-pointer">
+                        <span class="text-white font-mono text-xs font-bold">{ }</span>
+                    </button>
+                    <div id="profileDropdown" class="profile-dropdown absolute right-0 mt-2 w-56 bg-white border-2 border-gray-200 rounded-xl shadow-xl z-50">
+                        <div class="py-2">
+                            <a href="/my-courses" class="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors">
+                                <i class="fa-solid fa-video text-gray-600"></i>
+                                <span class="text-sm font-medium text-gray-900">내 강의</span>
+                            </a>
+                            <a href="/user/me" class="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors">
+                                <i class="fa-solid fa-gear text-gray-600"></i>
+                                <span class="text-sm font-medium text-gray-900">계정 설정</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+
+<!-- Page Title -->
+<div class="max-w-7xl mx-auto px-6 pt-8 pb-2">
+    <h1 class="text-2xl font-black text-gray-900">계정 설정</h1>
+</div>
+
+<div class="max-w-7xl mx-auto px-6 py-8">
+    <div class="grid grid-cols-12 gap-8">
+
+        <!-- Left Sidebar -->
+        <div class="col-span-3">
+            <div class="bg-white border-2 border-gray-200 rounded-2xl p-6 sticky top-24">
+                <h2 class="text-xl font-black text-gray-900 mb-6">설정</h2>
+                <nav class="space-y-2">
+                    <a th:if="${myPage.role.name() == 'INSTRUCTOR'}"
+                       th:href="@{/instructor/course-management}" href="/instructor/course-management"
+                       class="flex items-center gap-3 px-4 py-3 rounded-xl text-gray-700 hover:bg-gray-50 font-medium transition-all">
+                        <i class="fa-solid fa-video w-5 h-5"></i>
+                        <span class="text-sm">내 강의 관리</span>
+                    </a>
+                    <a th:unless="${myPage.role.name() == 'INSTRUCTOR'}"
+                       th:href="@{/my-courses}" href="/my-courses"
+                       class="flex items-center gap-3 px-4 py-3 rounded-xl text-gray-700 hover:bg-gray-50 font-medium transition-all">
+                        <i class="fa-solid fa-video w-5 h-5"></i>
+                        <span class="text-sm">내 강의</span>
+                    </a>
+                    <a th:href="@{/user/me}" href="/user/me"
+                       class="flex items-center gap-3 px-4 py-3 rounded-xl bg-blue-50 text-blue-600 font-bold transition-all">
+                        <i class="fa-solid fa-gear w-5 h-5"></i>
+                        <span class="text-sm">계정 설정</span>
+                    </a>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Main Content -->
+        <div class="col-span-9 space-y-8">
+
+            <!-- 성공/에러 메시지 -->
+            <div th:if="${successMessage}" class="p-4 bg-green-50 border-2 border-green-200 rounded-xl">
+                <p class="text-sm font-bold text-green-600" th:text="${successMessage}"></p>
+            </div>
+            <div th:if="${errorMessage}" class="p-4 bg-red-50 border-2 border-red-200 rounded-xl">
+                <p class="text-sm font-bold text-red-600" th:text="${errorMessage}"></p>
+            </div>
+
+            <!-- 프로필 설정 -->
+            <div class="bg-white border-2 border-gray-200 rounded-2xl p-8">
+                <h2 class="text-2xl font-black text-gray-900 mb-6">프로필 설정</h2>
+
+                <div class="flex items-start gap-8">
+                    <!-- 프로필 이미지 -->
+                    <div class="flex-shrink-0">
+                        <div class="w-32 h-32 rounded-2xl bg-gradient-to-br from-blue-100 to-green-100 border-4 border-white shadow-xl flex items-center justify-center overflow-hidden">
+                            <img th:if="${myPage.profileImg != null}"
+                                 th:src="${myPage.profileImg}"
+                                 alt="프로필 이미지"
+                                 class="w-full h-full object-cover"/>
+                            <i th:unless="${myPage.profileImg != null}"
+                               class="fa-solid fa-user text-gray-400 text-5xl"></i>
+                        </div>
+                    </div>
+
+                    <!-- 이미지 컨트롤 -->
+                    <div class="flex-1 space-y-4">
+                        <div class="flex gap-3">
+                            <form th:action="@{/user/me/profile-image}" method="POST" enctype="multipart/form-data">
+                                <label class="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-all font-bold cursor-pointer">
+                                    <i class="fa-solid fa-upload w-4 h-4"></i>
+                                    <span>프로필 업로드</span>
+                                    <input type="file" name="profileImg" accept="image/*" class="hidden"
+                                           onchange="this.form.submit()"/>
+                                </label>
+                            </form>
+                            <form th:action="@{/user/me/profile-image/delete}" method="POST">
+                                <button type="submit"
+                                        class="inline-flex items-center gap-2 px-6 py-3 border-2 border-gray-300 text-gray-700 rounded-xl hover:border-red-500 hover:text-red-600 hover:bg-red-50 transition-all font-bold">
+                                    <i class="fa-solid fa-trash w-4 h-4"></i>
+                                    <span>프로필 삭제</span>
+                                </button>
+                            </form>
+                        </div>
+                        <p class="text-sm text-gray-600">JPG, PNG 또는 GIF (최대 5MB)</p>
+                    </div>
+                </div>
+
+                <!-- 닉네임 수정 -->
+                <div class="mt-8 pt-8 border-t-2 border-gray-200">
+                    <label class="block text-sm font-bold text-gray-700 mb-2">닉네임</label>
+                    <form th:action="@{/user/me/nickname}" method="POST" class="flex gap-3">
+                        <input type="text" name="nickname"
+                               th:value="${myPage.nickname}"
+                               class="flex-1 px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-600 focus:outline-none transition-colors font-medium"/>
+                        <button type="submit"
+                                class="px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-all font-bold">
+                            저장
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            <!-- 비밀번호 변경 -->
+            <div class="bg-white border-2 border-gray-200 rounded-2xl p-8">
+                <h2 class="text-2xl font-black text-gray-900 mb-6 flex items-center gap-2">
+                    <i class="fa-solid fa-lock text-blue-600"></i>
+                    <span>비밀번호 변경</span>
+                </h2>
+                <form th:action="@{/user/me/password}" method="POST" class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-bold text-gray-700 mb-2">현재 비밀번호</label>
+                        <div class="relative">
+                            <input type="password" id="currentPassword" name="currentPassword"
+                                   placeholder="현재 비밀번호를 입력하세요"
+                                   class="w-full px-4 py-3 pr-12 border-2 border-gray-200 rounded-xl focus:border-blue-600 focus:outline-none transition-colors font-medium"/>
+                            <button type="button" onclick="togglePassword('currentPassword', this)"
+                                    class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+                                <i class="fa-solid fa-eye"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-bold text-gray-700 mb-2">새 비밀번호</label>
+                        <div class="relative">
+                            <input type="password" id="newPassword" name="newPassword"
+                                   placeholder="새 비밀번호를 입력하세요"
+                                   class="w-full px-4 py-3 pr-12 border-2 border-gray-200 rounded-xl focus:border-blue-600 focus:outline-none transition-colors font-medium"/>
+                            <button type="button" onclick="togglePassword('newPassword', this)"
+                                    class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+                                <i class="fa-solid fa-eye"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-bold text-gray-700 mb-2">새 비밀번호 확인</label>
+                        <div class="relative">
+                            <input type="password" id="confirmPassword" name="confirmPassword"
+                                   placeholder="새 비밀번호를 다시 입력하세요"
+                                   class="w-full px-4 py-3 pr-12 border-2 border-gray-200 rounded-xl focus:border-blue-600 focus:outline-none transition-colors font-medium"/>
+                            <button type="button" onclick="togglePassword('confirmPassword', this)"
+                                    class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+                                <i class="fa-solid fa-eye"></i>
+                            </button>
+                        </div>
+                        <p id="pwMatchMsg" class="text-xs mt-1 hidden"></p>
+                    </div>
+                    <button type="submit"
+                            class="w-full py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-all font-bold">
+                        비밀번호 변경
+                    </button>
+                </form>
+            </div>
+
+            <!-- 이메일 변경 -->
+            <div class="bg-white border-2 border-gray-200 rounded-2xl p-8">
+                <h2 class="text-2xl font-black text-gray-900 mb-6 flex items-center gap-2">
+                    <i class="fa-solid fa-envelope text-blue-600"></i>
+                    <span>이메일 변경</span>
+                </h2>
+                <form th:action="@{/user/me/email}" method="POST" class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-bold text-gray-700 mb-2">새 이메일</label>
+                        <input type="email" name="email"
+                               th:placeholder="${myPage.email}"
+                               class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-600 focus:outline-none transition-colors font-medium"/>
+                    </div>
+                    <button type="submit"
+                            class="w-full py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-all font-bold">
+                        이메일 변경
+                    </button>
+                </form>
+            </div>
+
+            <!-- 계정 삭제 -->
+            <div class="bg-white border-2 border-gray-200 rounded-2xl p-8">
+                <h2 class="text-2xl font-black text-gray-900 mb-2 flex items-center gap-2">
+                    <i class="fa-solid fa-triangle-exclamation text-red-500"></i>
+                    <span>계정 삭제</span>
+                </h2>
+                <p class="text-sm text-gray-600 mb-6 font-medium">계정 삭제 시 프로필 및 모든 학습 정보가 삭제되며 복구할 수 없습니다.</p>
+                <div class="flex justify-end pt-4 border-t-2 border-gray-100">
+                    <button type="button" onclick="openWithdrawModal()"
+                            class="px-6 py-3 border-2 border-red-400 text-red-500 rounded-xl font-bold hover:bg-red-50 transition-all">
+                        회원 탈퇴 진행하기
+                    </button>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<!-- 탈퇴 확인 모달 -->
+<div id="withdrawModal" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div class="bg-white rounded-2xl p-8 w-full max-w-md mx-4 shadow-2xl">
+        <h3 class="text-xl font-black text-gray-900 mb-2">정말 탈퇴하시겠습니까?</h3>
+        <p class="text-sm text-gray-600 mb-6">탈퇴 후 모든 데이터는 복구할 수 없습니다.</p>
+        <form th:action="@{/user/me/withdraw}" method="POST" class="space-y-4">
+            <div>
+                <label class="block text-sm font-bold text-gray-700 mb-2">현재 비밀번호</label>
+                <div class="relative">
+                    <input type="password" id="withdrawPassword" name="password"
+                           placeholder="비밀번호를 입력하세요"
+                           class="w-full px-4 py-3 pr-12 border-2 border-gray-200 rounded-xl focus:border-red-500 focus:outline-none transition-colors font-medium"/>
+                    <button type="button" onclick="togglePassword('withdrawPassword', this)"
+                            class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+                        <i class="fa-solid fa-eye"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="flex gap-3">
+                <button type="button" onclick="closeWithdrawModal()"
+                        class="flex-1 py-3 border-2 border-gray-300 text-gray-700 rounded-xl font-bold hover:bg-gray-50 transition-all">
+                    취소
+                </button>
+                <button type="submit"
+                        class="flex-1 py-3 bg-red-500 text-white rounded-xl font-bold hover:bg-red-600 transition-all">
+                    탈퇴 확정
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<!-- Footer -->
+<footer class="border-t border-gray-200 bg-white mt-16">
+    <div class="max-w-7xl mx-auto px-6 py-8">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+                <i class="fa-solid fa-terminal text-blue-600"></i>
+                <span class="text-sm font-bold text-gray-600">© 2026 Nae-Il. 코딩으로 만드는 내일</span>
+            </div>
+            <div class="flex items-center gap-6 text-sm text-gray-600">
+                <a href="#" class="hover:text-blue-600 transition-colors">이용약관</a>
+                <a href="#" class="hover:text-blue-600 transition-colors">개인정보처리방침</a>
+                <a href="#" class="hover:text-blue-600 transition-colors">고객센터</a>
+            </div>
+        </div>
+    </div>
+</footer>
+
+<script>
+    function toggleNoticeDropdown() {
+        const el = document.getElementById('noticeDropdown');
+        if (el) el.classList.toggle('open');
+    }
+    function toggleProfileDropdown() {
+        const el = document.getElementById('profileDropdown');
+        if (el) el.classList.toggle('open');
+    }
+    function toggleInstructorProfileDropdown() {
+        const el = document.getElementById('instructorProfileDropdown');
+        if (el) {
+            el.style.display = el.style.display === 'none' || el.style.display === '' ? 'block' : 'none';
+        }
+    }
+    document.addEventListener('click', function(e) {
+        const noticeWrapper = document.getElementById('noticeDropdownWrapper');
+        const profileWrapper = document.getElementById('profileDropdownWrapper');
+        const instructorWrapper = document.getElementById('instructorProfileDropdownWrapper');
+
+        if (noticeWrapper && !noticeWrapper.contains(e.target)) {
+            const el = document.getElementById('noticeDropdown');
+            if (el) el.classList.remove('open');
+        }
+        if (profileWrapper && !profileWrapper.contains(e.target)) {
+            const el = document.getElementById('profileDropdown');
+            if (el) el.classList.remove('open');
+        }
+        if (instructorWrapper && !instructorWrapper.contains(e.target)) {
+            const el = document.getElementById('instructorProfileDropdown');
+            if (el) el.style.display = 'none';
+        }
+    });
+
+    function togglePassword(inputId, button) {
+        const input = document.getElementById(inputId);
+        const isPassword = input.getAttribute('type') === 'password';
+        input.setAttribute('type', isPassword ? 'text' : 'password');
+        const icon = button.querySelector('i');
+        icon.classList.toggle('fa-eye', !isPassword);
+        icon.classList.toggle('fa-eye-slash', isPassword);
+    }
+
+    const newPw = document.getElementById('newPassword');
+    const confirmPw = document.getElementById('confirmPassword');
+    const pwMatchMsg = document.getElementById('pwMatchMsg');
+
+    function checkPasswordMatch() {
+        if (confirmPw.value === '') {
+            pwMatchMsg.classList.add('hidden');
+            return;
+        }
+        if (newPw.value === confirmPw.value) {
+            pwMatchMsg.textContent = '비밀번호가 일치합니다.';
+            pwMatchMsg.className = 'text-xs mt-1 text-green-500 block';
+        } else {
+            pwMatchMsg.textContent = '비밀번호가 일치하지 않습니다.';
+            pwMatchMsg.className = 'text-xs mt-1 text-red-500 block';
+        }
+    }
+
+    newPw.addEventListener('input', checkPasswordMatch);
+    confirmPw.addEventListener('input', checkPasswordMatch);
+
+    function openWithdrawModal() {
+        document.getElementById('withdrawModal').classList.remove('hidden');
+    }
+    function closeWithdrawModal() {
+        document.getElementById('withdrawModal').classList.add('hidden');
+        document.getElementById('withdrawPassword').value = '';
+    }
+    document.getElementById('withdrawModal').addEventListener('click', function(e) {
+        if (e.target === this) closeWithdrawModal();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 계정 설정 - 프로필 정보 수정 , 회원 탈퇴 로직 구현
- 강사 헤더 대시보드 드롭다운 되게 수정

## 💡 어떤 기능인가요?
- (회원 관리: 보안 강화를 위한 임시 비밀번호 발급 및 사용자의 능동적인 서비스 탈퇴 기능 구현

- 대시보드 개선: 강사/헤더 대시보드 내 드롭다운 미작동 이슈 해결 및 UX 향상

- 
## ✨ 변경 사항 (Changes)
- User 엔티티: 상태 변경 및 정보 수정을 위한 비즈니스 메서드 추가

- 회원 탈퇴 로직 추가

- User/Auth Controller: 마이페이지 정보 수정 및 탈퇴 엔드포인트 구현

- UI/UX: - instructorDashboard.html, instructorHeader.html: 드롭다운 JS 로직 수정

login.html: 로딩 애니메이션 및 자동 저장 스크립트 추가

## 📝 작업 상세 내용
- [ ] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] JUnit 단위 테스트 (Controller, Service) 통과 확인
- [x] Postman을 통한 로컬 환경 API 엔드포인트 응답 테스트 완료

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 동시성 처리 부분에서 락(Lock)을 걸었는데, 성능상 문제가 없을지 중점적으로 봐주시면 감사하겠습니다!

## ✅ 체크 리스트
- [ ] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [ ] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [ ] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #117