### PR TITLE
실시간 강의 신청 페이지 조회 및 등록 요청 기능 구현 완료

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/admin/entity/AdminApproval.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/entity/AdminApproval.java
@@ -42,10 +42,6 @@ public class AdminApproval extends BaseTimeEntity {
     private InstructorApplications instructorApplications;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "instructor_id")
-    private User instructor;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "admin_id")
     private User admin;
 

--- a/src/main/java/com/wanted/naeil/domain/admin/repository/AdminApprovalRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/repository/AdminApprovalRepository.java
@@ -3,6 +3,7 @@ package com.wanted.naeil.domain.admin.repository;
 import com.wanted.naeil.domain.admin.entity.enums.ApprovalRequestType;
 import com.wanted.naeil.domain.admin.entity.enums.ApprovalStatus;
 import com.wanted.naeil.domain.admin.entity.AdminApproval;
+import com.wanted.naeil.domain.user.entity.InstructorApplications;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -16,4 +17,7 @@ public interface AdminApprovalRepository extends JpaRepository<AdminApproval, Lo
             ApprovalRequestType requestType,
             ApprovalStatus status
     );
+
+    // 승재 추가 : 강사 스스로 강사 신청 철회
+    void deleteByInstructorApplications(InstructorApplications instructorApplications);
 }

--- a/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
@@ -35,10 +35,12 @@ public class InstCourseController {
 
     // 코스 등록 조회
     @GetMapping("/course")
-    public ModelAndView CreateCoursePage(ModelAndView mv) {
+    public ModelAndView CreateCoursePage(ModelAndView mv,
+                                         @AuthenticationPrincipal AuthDetails authDetails) {
         log.info(" [Courses] 강의 생성 페이지 조회 시작");
 
         // TODO : 임시로 리포에서 바로 불러옴, 추후 서비스 로직 호출해서 하는걸로 수정
+        mv.addObject("user", authDetails.getLoginUserDTO());
         mv.addObject("createCourseRequest", new CourseCreateRequest());
         mv.addObject("categories", categoryRepository.findAll());
 

--- a/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
@@ -1,0 +1,104 @@
+package com.wanted.naeil.domain.live.controller;
+
+import com.wanted.naeil.domain.live.dto.CreateLiveLectureRequest;
+import com.wanted.naeil.domain.live.service.LiveLectureService;
+import com.wanted.naeil.domain.user.entity.enums.Role;
+import com.wanted.naeil.global.auth.model.dto.AuthDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/instructor")
+@Slf4j
+public class InstLiveController {
+
+    private final LiveLectureService liveLectureService;
+
+    /**
+     * 실시간 강의 신청 페이지 조회
+     * @param authDetails : 사용자가 강사 or 관리자인지 검증
+     * @param mv : request 값 바인딩, 및 html 페이지 설정
+     * @return : liveLectureCreate.html로 이동
+     */
+    @GetMapping("/live-lecture")
+    public ModelAndView createLiveLecture(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            ModelAndView mv
+            ) {
+        // 로그인 검증
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        Role userRole = authDetails.getLoginUserDTO().getRole();
+
+        // 권한 검증
+        if (userRole != Role.INSTRUCTOR && userRole != Role.ADMIN) {
+            throw new AccessDeniedException("관리자 혹은 강사만 생성 할 수 있습니다.");
+        }
+
+        log.info("[Live Lecture] 실시간 강의 신청 페이지 조회 시작");
+
+        mv.addObject("user", authDetails.getLoginUserDTO());
+        mv.addObject("createLiveLectureRequest",  new CreateLiveLectureRequest());
+        mv.setViewName("live/liveLectureCreate");
+
+        return mv;
+    }
+
+    @PostMapping("/live-lecture")
+    public ModelAndView registerLiveLecture(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @Valid @ModelAttribute CreateLiveLectureRequest request,
+            BindingResult bindingResult,
+            ModelAndView mv,
+            RedirectAttributes redirectAttributes
+    ) {
+
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        Long instructorId = authDetails.getLoginUserDTO().getUserId();
+
+        log.info("[LiveLecture] 라이브 강의 신청 요청 - instructorId: {}, instructorName: {}, title: {}",
+                instructorId,
+                authDetails.getLoginUserDTO().getName(),
+                request.getTitle());
+
+        if (bindingResult.hasErrors()) {
+            log.warn(" [Validation] 강의 등록 검증 실패: {}", bindingResult.getAllErrors());
+
+            mv.addObject("user", authDetails.getLoginUserDTO());
+            mv.addObject("createLiveLectureRequest", request);
+            mv.setViewName("live/liveLectureCreate");
+            return mv;
+        }
+
+        try {
+            String message = liveLectureService.registerLiveLecture(instructorId, request);
+            redirectAttributes.addFlashAttribute("message", message);
+            mv.setViewName("redirect:/instructor/course/complete");
+        } catch (Exception e) {
+            mv.addObject("errorMessage", "실시간 강의 등록 중 오류가 발생했습니다: " + e.getMessage());
+            mv.addObject("user", authDetails.getLoginUserDTO());
+            mv.addObject("createLiveLectureRequest", request);
+            mv.addObject("errorMessage", "강의 등록 중 오류가 발생했습니다: " + e.getMessage());
+            mv.setViewName("live/liveLectureCreate");
+        }
+
+        return mv;
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/live/dto/CreateLiveLectureRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/live/dto/CreateLiveLectureRequest.java
@@ -1,0 +1,44 @@
+package com.wanted.naeil.domain.live.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateLiveLectureRequest {
+
+    @NotBlank(message = "실시간 강의 제목은 필수 입력 사항입니다.")
+    @Size(max = 100, message = "강의 제목은 100자 이내여야 합니다.")
+    private String title;
+
+    @NotBlank(message = "강의 설명은 필수 입력 사항입니다.")
+    private String description;
+
+    @NotNull(message = "수강 정원은 필수 입력 사항입니다.")
+    @Min(value = 1, message = "수강 정원은 최소 1명 이상이어야 합니다.")
+    @Max(value = 100, message = "신청 가능한 최대 수강 정원은 100명입니다.")
+    private Integer maxCapacity;
+
+    @NotNull(message = "강의 시작 일시는 필수 입력 사항입니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime startAt;
+
+    @NotNull(message = "강의 종료 일시는 필수 입력 사항입니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime endAt;
+
+    @NotNull(message = "예약 시작 일시는 필수 입력 사항입니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime reservationStartAt;
+
+    @NotBlank(message = "방송 URL은 필수 입력 사항입니다.")
+    @Size(max = 500, message = "방송 URL은 500자 이내여야 합니다.")
+    private String streamingUrl;
+
+}

--- a/src/main/java/com/wanted/naeil/domain/live/entity/LiveLecture.java
+++ b/src/main/java/com/wanted/naeil/domain/live/entity/LiveLecture.java
@@ -55,15 +55,18 @@ public class LiveLecture extends BaseTimeEntity {
 
     @Builder
     public LiveLecture(User instructor, String title, String description, int maxCapacity,
-                       LocalDateTime reservationStartAt, LocalDateTime startAt, LocalDateTime endAt) {
+                       LocalDateTime reservationStartAt,
+                       LocalDateTime startAt, LocalDateTime endAt,
+                       String streamingUrl) {
         this.instructor = instructor;
         this.title = title;
         this.description = description;
-        this.maxCapacity = maxCapacity;
         this.currentCount = 0;
+        this.maxCapacity = maxCapacity;
         this.reservationStartAt = reservationStartAt;
         this.startAt = startAt;
         this.endAt = endAt;
+        this.streamingUrl = streamingUrl;
         this.status = LiveLectureStatus.PENDING;
     }
 

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -1,0 +1,120 @@
+package com.wanted.naeil.domain.live.service;
+
+import com.wanted.naeil.domain.admin.entity.AdminApproval;
+import com.wanted.naeil.domain.admin.repository.AdminApprovalRepository;
+import com.wanted.naeil.domain.live.dto.CreateLiveLectureRequest;
+import com.wanted.naeil.domain.live.entity.LiveLecture;
+import com.wanted.naeil.domain.live.repository.LiveLectureRepository;
+import com.wanted.naeil.domain.user.entity.User;
+import com.wanted.naeil.domain.user.entity.enums.Role;
+import com.wanted.naeil.domain.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LiveLectureService {
+
+    private final LiveLectureRepository liveLectureRepository;
+    private final UserRepository userRepository;
+    private final AdminApprovalRepository adminApprovalRepository;
+
+    @Transactional
+    public String registerLiveLecture(Long instructorId, @Valid CreateLiveLectureRequest request) {
+
+        // 사용자 존재 확인
+        User instructor = userRepository.findById(instructorId)
+                .orElseThrow(() -> new IllegalArgumentException("강사 정보를 찾을 수 없습니다. ID: " + instructorId));
+
+        // 관리자 role값 체크
+        if (instructor.getRole() != Role.INSTRUCTOR && instructor.getRole() != Role.ADMIN) {
+            throw new AccessDeniedException("강사 권한이 있는 사용자만 강의를 등록할 수 있습니다.");
+        }
+
+        // 제목 체크
+        if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
+            throw new IllegalArgumentException("강의 제목 필수 입력 값입니다.");
+        }
+
+        // 설명 체크
+        if (request.getDescription() == null || request.getDescription().trim().isEmpty()) {
+            throw new IllegalArgumentException("강의 설명은 필수 입력 값입니다.");
+        }
+
+        // 수강 정원 체크
+        if (request.getMaxCapacity() == null || request.getMaxCapacity() < 1) {
+            throw new IllegalArgumentException("올바른 수강 정원 값을 입력해주세요.");
+        }
+
+        // 방송 url 체크
+        if (request.getStreamingUrl() == null || request.getStreamingUrl().trim().isEmpty()) {
+            throw new IllegalArgumentException("방송 URL은 필수 입력 값 입니다.");
+        }
+
+        // 시간 관련 검증
+        validateLiveLectureTime(request);
+
+        LiveLecture liveLecture = LiveLecture.builder()
+                .instructor(instructor)
+                .title(request.getTitle().trim())
+                .description(request.getDescription().trim())
+                .maxCapacity(request.getMaxCapacity())
+                .reservationStartAt(request.getReservationStartAt())
+                .startAt(request.getStartAt())
+                .endAt(request.getEndAt())
+                .streamingUrl(request.getStreamingUrl().trim())
+                .build();
+
+        // 저장
+        LiveLecture savedLiveLecture = liveLectureRepository.save(liveLecture);
+
+        // 관리자 승인 DB에 추기
+        AdminApproval adminApproval = new AdminApproval(savedLiveLecture);
+        adminApprovalRepository.save(adminApproval);
+
+        return "강의 등록 신청이 완료되었습니다. 관리자 승인 후 강의가 활성화됩니다.";
+    }
+
+    // ====== 내부 편의 메서드 =======
+    private void validateLiveLectureTime(CreateLiveLectureRequest request) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startAt = request.getStartAt();
+        LocalDateTime endAt = request.getEndAt();
+        LocalDateTime reservationStartAt = request.getReservationStartAt();
+
+        if (startAt == null) {
+            throw new IllegalArgumentException("강의 시작 일시는 필수 입력 값입니다.");
+        }
+
+        if (endAt == null) {
+            throw new IllegalArgumentException("강의 종료 일시는 필수 입력 값입니다.");
+        }
+
+        if (reservationStartAt == null) {
+            throw new IllegalArgumentException("예약 시작 일시는 필수 입력 값입니다.");
+        }
+
+        if (startAt.isBefore(now)) {
+            throw new IllegalArgumentException("강의 시작 일시는 현재 시간 이후여야 합니다.");
+        }
+
+        if (!endAt.isAfter(startAt)) {
+            throw new IllegalArgumentException("강의 종료 일시는 강의 시작 일시보다 늦어야 합니다.");
+        }
+
+        if (reservationStartAt.isBefore(now)) {
+            throw new IllegalArgumentException("예약 시작 일시는 현재 시간 이후여야 합니다.");
+        }
+
+        if (!reservationStartAt.isBefore(startAt)) {
+            throw new IllegalArgumentException("예약 시작 일시는 강의 시작 일시보다 빨라야 합니다.");
+        }
+    }
+}

--- a/src/main/resources/templates/course/InstructorCourseManagement.html
+++ b/src/main/resources/templates/course/InstructorCourseManagement.html
@@ -203,8 +203,8 @@
         <p class="text-gray-600 font-medium">등록한 실시간 강의를 조회하고 관리할 수 있습니다</p>
       </div>
 
-      <a href="#"
-         onclick="alert('실시간 강의 신청 기능은 준비 중입니다.'); return false;"
+      <a th:href="@{/instructor/live-lecture}"
+         href="/instructor/live-lecture"
          class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-xl transition-all font-bold">
         <i class="fa-solid fa-plus"></i>
         실시간 강의 신청하기
@@ -276,8 +276,8 @@
       <h3 class="text-3xl font-black text-gray-900 mb-4">등록된 실시간 강의가 없습니다</h3>
       <p class="text-xl text-gray-500 font-medium mb-8">새로운 실시간 강의를 등록해보세요</p>
 
-      <a href="#"
-         onclick="alert('실시간 강의 신청 기능은 준비 중입니다.'); return false;"
+      <a th:href="@{/instructor/live-lecture}"
+         href="/instructor/live-lecture"
          class="inline-flex items-center gap-3 px-9 py-4 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-2xl hover:shadow-lg transition-all font-black text-lg">
         <i class="fa-solid fa-plus"></i>
         실시간 강의 신청하기

--- a/src/main/resources/templates/live/liveLectureCreate.html
+++ b/src/main/resources/templates/live/liveLectureCreate.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>실시간 강의 신청 | Nae-Il</title>
+
+    <meta name="_csrf" th:content="${_csrf != null ? _csrf.token : ''}">
+    <meta name="_csrf_header" th:content="${_csrf != null ? _csrf.headerName : ''}">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
+    <script src="https://unpkg.com/lucide@latest"></script>
+
+    <style>
+        body {
+            background-color: #f8fafc;
+        }
+    </style>
+</head>
+
+<body>
+<div th:replace="~{fragments/instructorHeader :: instructorHeader}"></div>
+
+<div class="max-w-7xl mx-auto px-6 py-12">
+    <div class="mb-10">
+        <a th:href="@{/instructor/course-management}"
+           href="/instructor/course-management"
+           class="inline-flex items-center gap-3 text-gray-600 hover:text-blue-600 transition-colors mb-6">
+            <i class="fa-solid fa-arrow-left text-sm"></i>
+            <span class="text-sm font-bold">이전으로</span>
+        </a>
+
+        <div class="flex items-end justify-between gap-6">
+            <div>
+                <h1 class="text-5xl font-black text-gray-900 mb-4">강의 신청</h1>
+                <p class="text-2xl text-gray-600 font-medium">새로운 실시간 강의를 등록하세요</p>
+            </div>
+
+            <div class="flex gap-2 bg-gray-100 p-1 rounded-xl">
+                <a th:href="@{/instructor/course}"
+                   href="/instructor/course"
+                   class="px-8 py-3 rounded-lg font-black text-sm text-gray-600 hover:text-gray-900 transition-all">
+                    일반 강의
+                </a>
+
+                <a th:href="@{/instructor/live-lecture}"
+                   href="/instructor/live-lecture"
+                   class="px-8 py-3 rounded-lg font-black text-sm bg-white text-blue-600 shadow-md transition-all">
+                    실시간 강의
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div th:if="${errorMessage != null}"
+         class="mb-6 rounded-2xl border-2 border-red-200 bg-red-50 px-6 py-4 text-red-700 font-bold">
+        <span th:text="${errorMessage}">강의 등록 중 오류가 발생했습니다.</span>
+    </div>
+
+    <form id="liveLectureForm"
+          th:action="@{/instructor/live-lecture}"
+          action="/instructor/live-lecture"
+          th:object="${createLiveLectureRequest}"
+          method="post"
+          class="space-y-8"
+          onsubmit="return validateLiveLectureForm()">
+
+        <input type="hidden"
+               th:name="${_csrf != null ? _csrf.parameterName : '_csrf'}"
+               th:value="${_csrf != null ? _csrf.token : ''}"/>
+
+        <section class="bg-white border-2 border-gray-200 rounded-2xl p-10 shadow-lg">
+            <h2 class="text-3xl font-black text-gray-900 mb-8">실시간 강의 정보</h2>
+
+            <div class="space-y-7">
+                <div>
+                    <label for="title" class="block text-sm font-black text-gray-700 mb-3">
+                        강의명 <span class="text-red-500">*</span>
+                    </label>
+                    <input type="text"
+                           id="title"
+                           th:field="*{title}"
+                           required
+                           maxlength="100"
+                           placeholder="강의명을 입력하세요"
+                           class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900 placeholder:text-gray-400"/>
+
+                    <p th:if="${#fields.hasErrors('title')}"
+                       th:errors="*{title}"
+                       class="mt-2 text-sm font-bold text-red-600">
+                        강의명 오류
+                    </p>
+                </div>
+
+                <div>
+                    <label for="description" class="block text-sm font-black text-gray-700 mb-3">
+                        강의 설명 <span class="text-red-500">*</span>
+                    </label>
+                    <textarea id="description"
+                              th:field="*{description}"
+                              rows="6"
+                              required
+                              placeholder="강의 설명을 입력하세요"
+                              class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none resize-none font-bold text-gray-900 placeholder:text-gray-400"></textarea>
+
+                    <p th:if="${#fields.hasErrors('description')}"
+                       th:errors="*{description}"
+                       class="mt-2 text-sm font-bold text-red-600">
+                        강의 설명 오류
+                    </p>
+                </div>
+
+                <div>
+                    <label for="maxCapacity" class="block text-sm font-black text-gray-700 mb-3">
+                        수강 정원 <span class="text-red-500">*</span>
+                    </label>
+                    <input type="number"
+                           id="maxCapacity"
+                           th:field="*{maxCapacity}"
+                           min="1"
+                           max="100"
+                           required
+                           placeholder="수강 정원을 입력하세요"
+                           class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900 placeholder:text-gray-400"/>
+
+                    <p th:if="${#fields.hasErrors('maxCapacity')}"
+                       th:errors="*{maxCapacity}"
+                       class="mt-2 text-sm font-bold text-red-600">
+                        수강 정원 오류
+                    </p>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <label for="startAt" class="block text-sm font-black text-gray-700 mb-3">
+                            강의 시작 일시 <span class="text-red-500">*</span>
+                        </label>
+                        <input type="datetime-local"
+                               id="startAt"
+                               th:field="*{startAt}"
+                               required
+                               class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900"/>
+
+                        <p th:if="${#fields.hasErrors('startAt')}"
+                           th:errors="*{startAt}"
+                           class="mt-2 text-sm font-bold text-red-600">
+                            강의 시작 일시 오류
+                        </p>
+                    </div>
+
+                    <div>
+                        <label for="endAt" class="block text-sm font-black text-gray-700 mb-3">
+                            강의 종료 일시 <span class="text-red-500">*</span>
+                        </label>
+                        <input type="datetime-local"
+                               id="endAt"
+                               th:field="*{endAt}"
+                               required
+                               class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900"/>
+
+                        <p th:if="${#fields.hasErrors('endAt')}"
+                           th:errors="*{endAt}"
+                           class="mt-2 text-sm font-bold text-red-600">
+                            강의 종료 일시 오류
+                        </p>
+                    </div>
+                </div>
+
+                <div>
+                    <label for="reservationStartAt" class="block text-sm font-black text-gray-700 mb-3">
+                        예약 시작 일시 <span class="text-red-500">*</span>
+                    </label>
+                    <input type="datetime-local"
+                           id="reservationStartAt"
+                           th:field="*{reservationStartAt}"
+                           required
+                           class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900"/>
+
+                    <p th:if="${#fields.hasErrors('reservationStartAt')}"
+                       th:errors="*{reservationStartAt}"
+                       class="mt-2 text-sm font-bold text-red-600">
+                        예약 시작 일시 오류
+                    </p>
+                </div>
+
+                <div>
+                    <label for="streamingUrl" class="block text-sm font-black text-gray-700 mb-3">
+                        방송 URL <span class="text-red-500">*</span>
+                    </label>
+                    <input type="url"
+                           id="streamingUrl"
+                           th:field="*{streamingUrl}"
+                           required
+                           maxlength="500"
+                           placeholder="https://..."
+                           class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900 placeholder:text-gray-400"/>
+
+                    <p th:if="${#fields.hasErrors('streamingUrl')}"
+                       th:errors="*{streamingUrl}"
+                       class="mt-2 text-sm font-bold text-red-600">
+                        방송 URL 오류
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <div class="flex justify-end gap-4 pb-6">
+            <a th:href="@{/instructor/course-management}"
+               href="/instructor/course-management"
+               class="px-10 py-4 border-2 border-gray-300 rounded-xl hover:bg-gray-50 transition-all font-black text-gray-700">
+                취소
+            </a>
+
+            <button type="submit"
+                    class="px-10 py-4 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-xl transition-all font-black">
+                실시간 강의 등록
+            </button>
+        </div>
+    </form>
+</div>
+
+<script>
+    lucide.createIcons();
+
+    function validateLiveLectureForm() {
+        const startAt = document.getElementById('startAt').value;
+        const endAt = document.getElementById('endAt').value;
+        const reservationStartAt = document.getElementById('reservationStartAt').value;
+        const maxCapacity = Number(document.getElementById('maxCapacity').value);
+
+        if (!startAt || !endAt || !reservationStartAt) {
+            alert('강의 일시와 예약 시작 일시를 입력해주세요.');
+            return false;
+        }
+
+        if (maxCapacity < 1 || maxCapacity > 100) {
+            alert('수강 정원은 1명 이상 100명 이하로 입력해주세요.');
+            return false;
+        }
+
+        const now = new Date();
+        const startDate = new Date(startAt);
+        const endDate = new Date(endAt);
+        const reservationDate = new Date(reservationStartAt);
+
+        if (startDate < now) {
+            alert('강의 시작 일시는 현재 시간 이후여야 합니다.');
+            return false;
+        }
+
+        if (endDate <= startDate) {
+            alert('강의 종료 일시는 강의 시작 일시보다 늦어야 합니다.');
+            return false;
+        }
+
+        if (reservationDate < now) {
+            alert('예약 시작 일시는 현재 시간 이후여야 합니다.');
+            return false;
+        }
+
+        if (reservationDate >= startDate) {
+            alert('예약 시작 일시는 강의 시작 일시보다 빨라야 합니다.');
+            return false;
+        }
+
+        return true;
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 실시간 강의 신청 폼 조회 기능 추가
- 실시간 강의 신청 및 관리자 승인 요청 등록 기능 추가
- 실시간 강의 등록 요청을 `LIVE_REGISTER` 승인 타입으로 관리자 승인 목록에 연동
- Ref #140 
- Ref #141 
- 위 2개 참고

## 💡 어떤 기능인가요?
- 강사 또는 관리자가 실시간 강의 정보를 입력하여 관리자에게 등록 승인을 요청할 수 있는 기능
- 실시간 강의 신청 페이지 조회, 입력값 검증, 실시간 강의 저장, 관리자 승인 요청 생성까지 처리하는 기능
- 관리자는 기존 승인 목록에서 실시간 강의 등록 요청을 확인하고 승인 또는 반려 처리 가능

## ✨ 변경 사항 (Changes)
- `InstLiveController`에 실시간 강의 신청 페이지 조회 엔드포인트 추가
- `GET /instructor/live-lecture` 추가
- `POST /instructor/live-lecture` 추가
- `CreateLiveLectureRequest` DTO 추가 및 validation 적용
- `LiveLectureService.registerLiveLecture()` 실시간 강의 신청 로직 구현
- 실시간 강의 시간 검증 로직 추가
- `LiveLecture` 생성 시 기본 상태를 `PENDING`으로 저장
- 실시간 강의 신청 성공 시 `AdminApproval`에 `LIVE_REGISTER` 승인 요청 생성
- 관리자 승인 처리 시 실시간 강의 상태를 `APPROVED`로 변경하는 기존 흐름 연동
- 관리자 반려 처리 시 실시간 강의 상태를 `REJECTED`로 변경하는 기존 흐름 연동
- 실시간 강의 신청 전용 Thymeleaf HTML 페이지 추가
- 강사 공통 헤더 적용
- 내 강의 관리 페이지에서 실시간 강의 신청 페이지 이동 링크 연결
- **DB 스키마 변경:** `admin_approvals` 테이블의 중복 컬럼 `instructor_id` 제거

## 📝 작업 상세 내용
- [x] 기능 구현
- [x] 버그 수정
- [x] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 강사 권한 사용자로 실시간 강의 신청 페이지 조회 확인
- [x] 실시간 강의 신청 폼 입력값 바인딩 확인
- [x] 필수 입력값 누락 시 validation 동작 확인
- [x] 수강 정원 1명 미만 또는 100명 초과 입력 제한 확인
- [x] 강의 시작/종료 일시 및 예약 시작 일시 검증 확인
- [x] 실시간 강의 신청 시 `live_lectures` 테이블 저장 확인
- [x] 실시간 강의 신청 시 `admin_approvals` 테이블에 `LIVE_REGISTER` 요청 저장 확인
- [x] 관리자 승인 목록에서 실시간 강의 등록 요청 노출 확인
- [x] `admin_approvals.instructor_id` 제거 후 실시간 강의 신청 정상 동작 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- `admin_approvals` 테이블의 `instructor_id`는 `course_id`, `live_id`, `settlement_id`, `application_id`를 통해 요청자 정보를 추적할 수 있어 중복 컬럼으로 판단하여 제거했습니다.
- 실시간 강의 신청 시 `LiveLecture`는 `PENDING` 상태로 저장되고, 관리자 승인 요청은 `LIVE_REGISTER` 타입으로 생성됩니다.
- 관리자 승인/반려 시 실시간 강의 상태 변경이 기존 `AdminApprovalService` 흐름과 자연스럽게 연결되는지 중점적으로 확인 부탁드립니다.
- 실시간 강의 시간 검증 조건이 기획 의도와 맞는지 확인 부탁드립니다.

## ✅ 체크 리스트
- [ ] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [ ] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [ ] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #140 
- Closes #141 