### PR TITLE
강사의 내 강의 관리 속 실시간 강의 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
@@ -2,6 +2,8 @@ package com.wanted.naeil.domain.course.controller;
 
 import com.wanted.naeil.domain.course.dto.request.CourseStatusUpdateRequest;
 import com.wanted.naeil.domain.course.dto.request.CourseUpdateRequest;
+import com.wanted.naeil.domain.live.dto.response.InstructorLiveLectureResponse;
+import com.wanted.naeil.domain.live.service.LiveLectureService;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
 import com.wanted.naeil.domain.course.dto.request.CourseCreateRequest;
 import com.wanted.naeil.domain.course.dto.response.CourseEditResponse;
@@ -31,6 +33,7 @@ import java.util.List;
 public class InstCourseController {
 
     private final CourseService courseService;
+    private final LiveLectureService liveLectureService;
     private final CategoryRepository  categoryRepository;
 
     // 코스 등록 조회
@@ -98,11 +101,14 @@ public class InstCourseController {
 
         List<InstructorCourseResponse> courses =
                 courseService.getInstructorCourses(instructorId);
+
+        List<InstructorLiveLectureResponse> liveCourses =
+                liveLectureService.getInstructorLiveLectures(instructorId);
         // 헤더 정보
         mv.addObject("user", authDetails.getLoginUserDTO());
         mv.addObject("courses", courses);
         // TODO : 실시간 강의 등록하면 인자 넣기
-        mv.addObject("liveCourses", List.of());
+        mv.addObject("liveCourses", liveCourses);
         mv.setViewName("course/InstructorCourseManagement");
 
         return mv;

--- a/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
@@ -1,6 +1,6 @@
 package com.wanted.naeil.domain.live.controller;
 
-import com.wanted.naeil.domain.live.dto.CreateLiveLectureRequest;
+import com.wanted.naeil.domain.live.dto.request.CreateLiveLectureRequest;
 import com.wanted.naeil.domain.live.service.LiveLectureService;
 import com.wanted.naeil.domain.user.entity.enums.Role;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
@@ -58,6 +58,15 @@ public class InstLiveController {
         return mv;
     }
 
+    /**
+     * 실시간 강의 등록 form 제출 로직
+     * @param authDetails : 세션에 저장된 사용자 정보
+     * @param request : 실시간 강의 요청에 필요한 값들
+     * @param bindingResult : dto 필수 입력값 검증 처리
+     * @param mv : message, view 페이지
+     * @param redirectAttributes : 리다이렉트할 때, 메시지가 잘 보이게 추가
+     * @return : 성공 -> 성공 페이지, 실패 -> 값들 유지하면서 신청 폼 리다이렉트
+     */
     @PostMapping("/live-lecture")
     public ModelAndView registerLiveLecture(
             @AuthenticationPrincipal AuthDetails authDetails,

--- a/src/main/java/com/wanted/naeil/domain/live/dto/request/CreateLiveLectureRequest.java
+++ b/src/main/java/com/wanted/naeil/domain/live/dto/request/CreateLiveLectureRequest.java
@@ -1,4 +1,4 @@
-package com.wanted.naeil.domain.live.dto;
+package com.wanted.naeil.domain.live.dto.request;
 
 import jakarta.validation.constraints.*;
 import lombok.Getter;

--- a/src/main/java/com/wanted/naeil/domain/live/dto/response/InstructorLiveLectureResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/live/dto/response/InstructorLiveLectureResponse.java
@@ -1,0 +1,34 @@
+package com.wanted.naeil.domain.live.dto.response;
+
+import com.wanted.naeil.domain.live.entity.LiveLecture;
+import com.wanted.naeil.domain.live.entity.enums.LiveLectureStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InstructorLiveLectureResponse {
+
+    private Long liveId;
+    private LiveLectureStatus status;
+    private String statusDescription;
+    private String title;
+    private LocalDateTime startAt;
+    private int currentCount;
+    private int maxCapacity;
+
+    public static InstructorLiveLectureResponse of(LiveLecture liveLecture) {
+        return InstructorLiveLectureResponse.builder()
+                .liveId(liveLecture.getId())
+                .status(liveLecture.getStatus())
+                .statusDescription(liveLecture.getStatus().getDescription())
+                .title(liveLecture.getTitle())
+                .startAt(liveLecture.getStartAt())
+                .currentCount(liveLecture.getCurrentCount())
+                .maxCapacity(liveLecture.getMaxCapacity())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wanted/naeil/domain/live/entity/enums/LiveLectureStatus.java
+++ b/src/main/java/com/wanted/naeil/domain/live/entity/enums/LiveLectureStatus.java
@@ -10,7 +10,8 @@ public enum LiveLectureStatus {
     APPROVED("승인 완료"),
     REJECTED("반려됨"),
     IN_PROGRESS("방송 중"),
-    ENDED("종료됨");
+    ENDED("종료됨"),
+    CANCELLED("요청 취소");
 
     private final String description;
 }

--- a/src/main/java/com/wanted/naeil/domain/live/repository/LiveLectureRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/live/repository/LiveLectureRepository.java
@@ -1,7 +1,14 @@
 package com.wanted.naeil.domain.live.repository;
 
 import com.wanted.naeil.domain.live.entity.LiveLecture;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LiveLectureRepository extends JpaRepository<LiveLecture, Long> {
+
+    // 강사별 live 강의 리스트 조회
+    @EntityGraph(attributePaths = {"instructor"})
+    List<LiveLecture> findByInstructorIdOrderByCreatedAtDesc(Long instructorId);
 }

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -2,7 +2,8 @@ package com.wanted.naeil.domain.live.service;
 
 import com.wanted.naeil.domain.admin.entity.AdminApproval;
 import com.wanted.naeil.domain.admin.repository.AdminApprovalRepository;
-import com.wanted.naeil.domain.live.dto.CreateLiveLectureRequest;
+import com.wanted.naeil.domain.live.dto.request.CreateLiveLectureRequest;
+import com.wanted.naeil.domain.live.dto.response.InstructorLiveLectureResponse;
 import com.wanted.naeil.domain.live.entity.LiveLecture;
 import com.wanted.naeil.domain.live.repository.LiveLectureRepository;
 import com.wanted.naeil.domain.user.entity.User;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +28,7 @@ public class LiveLectureService {
     private final UserRepository userRepository;
     private final AdminApprovalRepository adminApprovalRepository;
 
+    // 실시간 강의 등록
     @Transactional
     public String registerLiveLecture(Long instructorId, @Valid CreateLiveLectureRequest request) {
 
@@ -81,6 +84,23 @@ public class LiveLectureService {
 
         return "강의 등록 신청이 완료되었습니다. 관리자 승인 후 강의가 활성화됩니다.";
     }
+
+    // 나의 실시간 강의 목록 조회
+    @Transactional
+    public List<InstructorLiveLectureResponse> getInstructorLiveLectures(Long instructorId) {
+
+        User instructor = userRepository.findById(instructorId)
+                .orElseThrow(() -> new IllegalArgumentException("강사 정보를 찾을 수 없습니다. ID: " + instructorId));
+
+        if (instructor.getRole() != Role.INSTRUCTOR && instructor.getRole() != Role.ADMIN) {
+            throw new AccessDeniedException("강사 권한이 있는 사용자만 실시간 강의 목록을 조회할 수 있습니다.");
+        }
+
+        return liveLectureRepository.findByInstructorIdOrderByCreatedAtDesc(instructorId).stream()
+                .map(InstructorLiveLectureResponse::of)
+                .toList();
+    }
+
 
     // ====== 내부 편의 메서드 =======
     private void validateLiveLectureTime(CreateLiveLectureRequest request) {

--- a/src/main/resources/templates/course/InstructorCourseManagement.html
+++ b/src/main/resources/templates/course/InstructorCourseManagement.html
@@ -212,60 +212,115 @@
     </div>
 
     <div th:if="${liveCourses != null and not #lists.isEmpty(liveCourses)}" class="space-y-4">
-      <div th:each="course : ${liveCourses}"
+      <div th:each="liveCourse : ${liveCourses}"
            class="bg-white border-2 border-gray-200 rounded-2xl p-6 hover:shadow-xl hover:border-blue-300 transition-all group">
         <div class="flex items-center justify-between gap-6">
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-3 mb-3">
-              <span th:text="${course.status}"
+          <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
+                class="px-3 py-1 bg-yellow-100 text-yellow-700 rounded-full text-sm font-bold">
+            승인 대기
+          </span>
+
+              <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
+                    class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-bold">
+            승인 완료
+          </span>
+
+              <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'REJECTED'}"
+                    class="px-3 py-1 bg-red-100 text-red-700 rounded-full text-sm font-bold">
+            반려됨
+          </span>
+
+              <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'IN_PROGRESS'}"
                     class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
-                예정중
-              </span>
+            방송 중
+          </span>
+
+              <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'ENDED'}"
+                    class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
+            종료됨
+          </span>
+
+              <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'CANCELLED'}"
+                    class="px-3 py-1 bg-orange-100 text-orange-700 rounded-full text-sm font-bold">
+            요청 취소
+          </span>
+
+              <span th:if="${liveCourse.status == null}"
+                    class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
+            상태 없음
+          </span>
             </div>
 
-            <h3 class="text-xl font-black text-gray-900 mb-3 group-hover:text-blue-600 transition-colors"
-                th:text="${course.title}">
+            <h3 class="text-xl font-black text-gray-900 mb-3 group-hover:text-blue-600 transition-colors truncate"
+                th:text="${liveCourse.title}">
               실시간 강의명
             </h3>
 
             <div class="flex items-center gap-4 text-sm">
-              <span class="font-bold text-gray-700">
-                <i class="fa-solid fa-calendar text-gray-500 mr-1"></i>
-                <span th:text="${course.datetime}">2026-04-20 19:00</span>
-              </span>
+          <span class="font-bold text-gray-700">
+            <i class="fa-solid fa-calendar text-gray-500 mr-1"></i>
+            <span th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd HH:mm') : '-'}">
+              2026-04-20 19:00
+            </span>
+          </span>
 
               <span class="font-bold text-gray-700">
-                <i class="fa-solid fa-users text-gray-500 mr-1"></i>
-                <span th:text="${course.registeredCount}">0</span>/<span th:text="${course.capacity}">0</span>명
-              </span>
+            <i class="fa-solid fa-users text-gray-500 mr-1"></i>
+            <span th:text="${liveCourse.currentCount}">0</span>/<span th:text="${liveCourse.maxCapacity}">0</span>명
+          </span>
             </div>
           </div>
 
           <div class="flex items-center gap-3">
-            <a th:href="@{/instructor/live-course/{id}(id=${course.id})}"
+            <a th:href="@{/instructor/live-lecture/{id}(id=${liveCourse.liveId})}"
                class="flex h-12 w-12 items-center justify-center rounded-xl border-2 border-blue-300 text-blue-600 transition-all hover:bg-blue-50"
                title="조회">
               <i class="fa-regular fa-eye"></i>
             </a>
 
-            <a th:href="@{/instructor/live-course/edit/{id}(id=${course.id})}"
+            <a th:if="${liveCourse.status != null and (liveCourse.status.name() == 'PENDING' or liveCourse.status.name() == 'APPROVED' or liveCourse.status.name() == 'REJECTED' or liveCourse.status.name() == 'CANCELLED')}"
+               th:href="@{/instructor/live-lecture/{id}/edit(id=${liveCourse.liveId})}"
                class="flex h-12 w-12 items-center justify-center rounded-xl border-2 border-green-300 text-green-600 transition-all hover:bg-green-50"
                title="수정">
               <i class="fa-regular fa-pen-to-square"></i>
             </a>
 
             <button type="button"
-                    th:data-id="${course.id}"
-                    th:data-title="${course.title}"
+                    th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
+                    th:data-id="${liveCourse.liveId}"
+                    th:data-title="${liveCourse.title}"
+                    onclick="updateLiveLectureRegistrationStatus(this, 'CANCELLED')"
+                    class="flex h-12 items-center justify-center rounded-xl border-2 border-yellow-300 px-4 text-yellow-700 transition-all hover:bg-yellow-50 font-bold whitespace-nowrap"
+                    title="등록 요청 취소">
+              요청 취소
+            </button>
+
+            <button type="button"
+                    th:if="${liveCourse.status != null and liveCourse.status.name() == 'CANCELLED'}"
+                    th:data-id="${liveCourse.liveId}"
+                    th:data-title="${liveCourse.title}"
+                    onclick="updateLiveLectureRegistrationStatus(this, 'PENDING')"
+                    class="flex h-12 items-center justify-center rounded-xl border-2 border-blue-300 px-4 text-blue-700 transition-all hover:bg-blue-50 font-bold whitespace-nowrap"
+                    title="등록 요청">
+              등록 요청
+            </button>
+
+            <button type="button"
+                    th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
+                    th:data-id="${liveCourse.liveId}"
+                    th:data-title="${liveCourse.title}"
                     onclick="openDeleteLiveModal(this)"
                     class="flex h-12 w-12 items-center justify-center rounded-xl border-2 border-red-300 text-red-600 transition-all hover:bg-red-50"
-                    title="삭제">
+                    title="삭제 요청">
               <i class="fa-regular fa-trash-can"></i>
             </button>
           </div>
         </div>
       </div>
     </div>
+
 
     <div th:if="${liveCourses == null or #lists.isEmpty(liveCourses)}"
          class="bg-white rounded-3xl border-2 border-dashed border-gray-200 py-24 text-center">
@@ -425,6 +480,41 @@
     };
   }
 
+  async function updateLiveLectureRegistrationStatus(button, nextStatus) {
+    const liveId = button.dataset.id;
+    const title = button.dataset.title || '';
+
+    const confirmMessage = nextStatus === 'CANCELLED'
+            ? `"${title}" 실시간 강의 등록 요청을 취소하시겠습니까?`
+            : `"${title}" 실시간 강의를 다시 등록 요청하시겠습니까?`;
+
+    if (!confirm(confirmMessage)) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.set('status', nextStatus);
+
+    const response = await fetch(`/instructor/live-lecture/${liveId}/registration-status`, {
+      method: 'PATCH',
+      headers: getCsrfHeaders(),
+      body: formData
+    });
+
+    if (!response.ok) {
+      alert('실시간 강의 등록 상태 변경에 실패했습니다.');
+      return;
+    }
+
+    const successMessage = nextStatus === 'CANCELLED'
+            ? '실시간 강의 등록 요청이 취소되었습니다.'
+            : '실시간 강의 등록 요청이 완료되었습니다.';
+
+    alert(successMessage);
+    location.reload();
+  }
+
+
   async function updateCourseRegistrationStatus(button, nextStatus) {
     const courseId = button.dataset.id;
     const title = button.dataset.title || '';
@@ -516,7 +606,7 @@
 
     const form = document.createElement('form');
     form.method = 'POST';
-    form.action = `/instructor/live-course/${currentDeleteLiveId}/delete-request`;
+    form.action = `/instructor/live-lecture/${currentDeleteLiveId}/delete-request`;
 
     const reasonInput = document.createElement('input');
     reasonInput.type = 'hidden';


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 내 강의 관리 페이지에 강사가 등록한 실시간 강의 목록 조회 기능 추가
- 실시간 강의 목록 응답 DTO 및 강사별 조회 로직 추가
- 실시간 강의 상태별 배지와 버튼 노출 조건 적용

## 💡 어떤 기능인가요?
- 강사가 `/instructor/course-management` 페이지에서 본인이 등록한 일반 강의와 실시간 강의를 함께 조회할 수 있는 기능
- 실시간 강의의 승인 상태, 제목, 시작 시간, 현재 예약 수, 총 정원을 확인할 수 있는 관리 기능
- 실시간 강의 상태에 따라 조회, 수정, 요청 취소, 등록 요청, 삭제 요청 버튼을 다르게 노출하는 화면 기능

## ✨ 변경 사항 (Changes)
- `InstructorLiveLectureResponse` DTO 추가
- `LiveLectureRepository`에 강사별 실시간 강의 목록 조회 메서드 추가
- `LiveLectureService`에 실시간 강의 목록 조회 로직 추가
- `/instructor/course-management` 컨트롤러에서 `liveCourses` 조회 및 Model 추가
- `InstructorCourseManagement.html` 실시간 강의 목록 렌더링 수정
- 실시간 강의 목록 표시 항목 추가
  - 실시간 강의 상태
  - 실시간 강의 제목
  - 실시간 강의 시작 시간
  - 현재 예약 수
  - 총 정원
- `LiveLectureStatus` 상태별 배지 표시 추가
  - 승인 대기
  - 승인 완료
  - 반려됨
  - 방송 중
  - 종료됨
  - 요청 취소
- 실시간 강의 상태별 버튼 노출 조건 추가
- 실시간 강의 목록 empty state 화면 유지 및 연결
- **DB 스키마 변경:** 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [x] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 강사 계정으로 `/instructor/course-management` 페이지 접근 확인
- [x] 일반 강의 목록 기존 조회 정상 동작 확인
- [x] 실시간 강의 목록 조회 정상 동작 확인
- [x] 실시간 강의 상태 배지 정상 표시 확인
- [x] 실시간 강의 제목 표시 확인
- [x] 실시간 강의 시작 시간 표시 확인
- [x] 현재 예약 수 / 총 정원 표시 확인
- [x] 실시간 강의 목록이 없는 경우 empty state 표시 확인
- [x] 상태별 버튼 노출 조건 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 기존 `/instructor/course-management` 페이지에서 일반 강의 목록과 실시간 강의 목록을 함께 보여주는 방식으로 구현했습니다.
- 실시간 강의 단독 페이지가 아닌 관리 화면 구성 데이터이므로 별도 컨트롤러를 만들지 않고 기존 내 강의 관리 컨트롤러에 `liveCourses`를 추가했습니다.
- 버튼 중 실시간 강의 등록 요청 취소, 재요청, 수정, 삭제 요청은 이후 기능 구현과 연결될 수 있도록 화면 조건만 먼저 반영했습니다.
- `LiveLectureStatus`별 버튼 노출 조건이 기획 의도와 맞는지 확인 부탁드립니다.

## ✅ 체크 리스트
- [ ] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [ ] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [ ] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때 해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #143 
