### PR TITLE
강사 - 실시간 조회 상세 조회 페이지 구현 완료

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
@@ -1,6 +1,7 @@
 package com.wanted.naeil.domain.live.controller;
 
 import com.wanted.naeil.domain.live.dto.request.CreateLiveLectureRequest;
+import com.wanted.naeil.domain.live.dto.response.InstructorLiveDetailResponse;
 import com.wanted.naeil.domain.live.service.LiveLectureService;
 import com.wanted.naeil.domain.user.entity.enums.Role;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
@@ -11,12 +12,11 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -101,12 +101,35 @@ public class InstLiveController {
             redirectAttributes.addFlashAttribute("message", message);
             mv.setViewName("redirect:/instructor/course/complete");
         } catch (Exception e) {
-            mv.addObject("errorMessage", "실시간 강의 등록 중 오류가 발생했습니다: " + e.getMessage());
             mv.addObject("user", authDetails.getLoginUserDTO());
             mv.addObject("createLiveLectureRequest", request);
-            mv.addObject("errorMessage", "강의 등록 중 오류가 발생했습니다: " + e.getMessage());
+            mv.addObject("errorMessage", "실시간 강의 등록 중 오류가 발생했습니다: " + e.getMessage());
             mv.setViewName("live/liveLectureCreate");
         }
+
+        return mv;
+    }
+
+    @GetMapping("/live-lecture/{liveId}")
+    public ModelAndView getInstructorLiveLectureDetail(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long liveId,
+            ModelAndView mv
+    ) {
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        Long instructorId = authDetails.getLoginUserDTO().getUserId();
+
+        InstructorLiveDetailResponse response =
+                liveLectureService.getInstructorLiveLectureDetail(instructorId, liveId);
+
+        mv.addObject("user", authDetails.getLoginUserDTO());
+        mv.addObject("liveCourse", response);
+        // TODO : 추후 예약자 명단 페이지 추가
+        mv.addObject("reservations", List.of());
+        mv.setViewName("live/liveLectureDetail");
 
         return mv;
     }

--- a/src/main/java/com/wanted/naeil/domain/live/dto/response/InstructorLiveDetailResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/live/dto/response/InstructorLiveDetailResponse.java
@@ -1,0 +1,43 @@
+package com.wanted.naeil.domain.live.dto.response;
+
+import com.wanted.naeil.domain.live.entity.LiveLecture;
+import com.wanted.naeil.domain.live.entity.enums.LiveLectureStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InstructorLiveDetailResponse {
+
+    private Long liveId;
+    private LiveLectureStatus status;
+    private String statusDescription;
+    private String title;
+    private String description;
+    private LocalDateTime reservationStartAt;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private String streamingUrl;
+    private int currentCount;
+    private int maxCapacity;
+    private LocalDateTime createdAt;
+
+    public static InstructorLiveDetailResponse of(LiveLecture lecture) {
+        return InstructorLiveDetailResponse.builder()
+                .liveId(lecture.getId())
+                .status(lecture.getStatus())
+                .statusDescription(lecture.getStatus().getDescription())
+                .title(lecture.getTitle())
+                .description(lecture.getDescription())
+                .reservationStartAt(lecture.getReservationStartAt())
+                .startAt(lecture.getStartAt())
+                .endAt(lecture.getEndAt())
+                .streamingUrl(lecture.getStreamingUrl())
+                .currentCount(lecture.getCurrentCount())
+                .maxCapacity(lecture.getMaxCapacity())
+                .createdAt(lecture.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -3,6 +3,7 @@ package com.wanted.naeil.domain.live.service;
 import com.wanted.naeil.domain.admin.entity.AdminApproval;
 import com.wanted.naeil.domain.admin.repository.AdminApprovalRepository;
 import com.wanted.naeil.domain.live.dto.request.CreateLiveLectureRequest;
+import com.wanted.naeil.domain.live.dto.response.InstructorLiveDetailResponse;
 import com.wanted.naeil.domain.live.dto.response.InstructorLiveLectureResponse;
 import com.wanted.naeil.domain.live.entity.LiveLecture;
 import com.wanted.naeil.domain.live.repository.LiveLectureRepository;
@@ -86,7 +87,7 @@ public class LiveLectureService {
     }
 
     // 나의 실시간 강의 목록 조회
-    @Transactional
+    @Transactional(readOnly = true)
     public List<InstructorLiveLectureResponse> getInstructorLiveLectures(Long instructorId) {
 
         User instructor = userRepository.findById(instructorId)
@@ -99,6 +100,24 @@ public class LiveLectureService {
         return liveLectureRepository.findByInstructorIdOrderByCreatedAtDesc(instructorId).stream()
                 .map(InstructorLiveLectureResponse::of)
                 .toList();
+    }
+
+    // 강사 - 실시간 강의 상세 조회
+    @Transactional(readOnly = true)
+    public InstructorLiveDetailResponse getInstructorLiveLectureDetail(Long instructorId, Long liveId) {
+
+        log.info("[실시간 강의] 상세 조회 Service 로직 시작!");
+
+        User instructor = userRepository.findById(instructorId)
+                .orElseThrow(() -> new IllegalArgumentException("강사 정보를 찾을 수 없습니다. ID: " + instructorId));
+
+        LiveLecture liveLecture = liveLectureRepository.findById(liveId)
+                .orElseThrow(() -> new IllegalArgumentException("실시간 강의를 찾을 수 없습니다. ID: " + liveId));
+
+
+        validateLiveLectureOwnerOrAdmin(instructor, liveLecture);
+
+        return InstructorLiveDetailResponse.of(liveLecture);
     }
 
 
@@ -135,6 +154,20 @@ public class LiveLectureService {
 
         if (!reservationStartAt.isBefore(startAt)) {
             throw new IllegalArgumentException("예약 시작 일시는 강의 시작 일시보다 빨라야 합니다.");
+        }
+    }
+
+    private void validateLiveLectureOwnerOrAdmin(User user, LiveLecture liveLecture) {
+        if (user.getRole() == Role.ADMIN) {
+            return;
+        }
+
+        if (user.getRole() != Role.INSTRUCTOR) {
+            throw new AccessDeniedException("강사 또는 관리자만 실시간 강의를 조회할 수 있습니다.");
+        }
+
+        if (!liveLecture.getInstructor().getId().equals(user.getId())) {
+            throw new AccessDeniedException("본인이 등록한 실시간 강의만 조회할 수 있습니다.");
         }
     }
 }

--- a/src/main/resources/templates/live/liveLectureDetail.html
+++ b/src/main/resources/templates/live/liveLectureDetail.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>실시간 강의 상세 | Nae-Il</title>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
+
+    <style>
+        body {
+            background-color: #f8fafc;
+        }
+
+        .tab-panel {
+            display: none;
+        }
+
+        .tab-panel.active {
+            display: block;
+        }
+    </style>
+</head>
+
+<body>
+<div th:replace="~{fragments/instructorHeader :: instructorHeader}"></div>
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+
+    <a th:href="@{/instructor/course-management}"
+       href="/instructor/course-management"
+       class="inline-flex items-center gap-2 text-gray-600 hover:text-blue-600 transition-colors mb-6">
+        <i class="fa-solid fa-arrow-left text-sm"></i>
+        <span class="text-sm font-bold">이전으로</span>
+    </a>
+
+    <div class="mb-8">
+        <div class="flex items-start justify-between gap-6 mb-4">
+            <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-3 mb-3">
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
+                          class="px-3 py-1 bg-yellow-100 text-yellow-700 rounded-full text-sm font-bold">
+                        승인 대기
+                    </span>
+
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
+                          class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-bold">
+                        승인 완료
+                    </span>
+
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'REJECTED'}"
+                          class="px-3 py-1 bg-red-100 text-red-700 rounded-full text-sm font-bold">
+                        반려됨
+                    </span>
+
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'IN_PROGRESS'}"
+                          class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
+                        방송 중
+                    </span>
+
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'ENDED'}"
+                          class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
+                        종료됨
+                    </span>
+
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'CANCELLED'}"
+                          class="px-3 py-1 bg-orange-100 text-orange-700 rounded-full text-sm font-bold">
+                        요청 취소
+                    </span>
+
+                    <span th:if="${liveCourse.status == null}"
+                          class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
+                        상태 없음
+                    </span>
+                </div>
+
+                <h1 class="text-4xl font-black text-gray-900 mb-3 truncate"
+                    th:text="${liveCourse.title}">
+                    실시간 강의명
+                </h1>
+
+                <p class="text-gray-500 font-medium">
+                    실시간 강의 정보와 예약생 현황을 확인할 수 있습니다.
+                </p>
+            </div>
+
+            <a th:if="${liveCourse.status != null and (liveCourse.status.name() == 'PENDING' or liveCourse.status.name() == 'APPROVED' or liveCourse.status.name() == 'REJECTED' or liveCourse.status.name() == 'CANCELLED')}"
+               th:href="@{/instructor/live-lecture/{id}/edit(id=${liveCourse.liveId})}"
+               href="/instructor/live-lecture/1/edit"
+               class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-xl transition-all font-bold">
+                <i class="fa-solid fa-pen text-sm"></i>
+                수정하기
+            </a>
+        </div>
+    </div>
+
+    <div class="mb-8">
+        <div class="flex gap-2 border-b-2 border-gray-200">
+            <button type="button"
+                    onclick="switchTab('info')"
+                    id="tab-btn-info"
+                    class="px-6 py-3 font-bold transition-all text-blue-600 border-b-2 border-blue-600 -mb-[2px]">
+                강의 조회
+            </button>
+
+            <button type="button"
+                    onclick="switchTab('reservations')"
+                    id="tab-btn-reservations"
+                    class="px-6 py-3 font-bold transition-all text-gray-600 hover:text-gray-900">
+                예약생 조회
+            </button>
+        </div>
+    </div>
+
+    <div id="tab-info" class="tab-panel active">
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+
+            <div class="lg:col-span-2 space-y-6">
+                <div class="bg-white border-2 border-gray-200 rounded-2xl p-8 shadow-sm">
+                    <h2 class="text-2xl font-black text-gray-900 mb-6">강의 정보</h2>
+
+                    <div class="space-y-7">
+                        <div>
+                            <h3 class="text-sm font-bold text-gray-600 mb-2">강의 제목</h3>
+                            <p class="text-base text-gray-900 font-bold"
+                               th:text="${liveCourse.title}">
+                                실시간 강의 제목
+                            </p>
+                        </div>
+
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <h3 class="text-sm font-bold text-gray-600 mb-2">강의 시작 일시</h3>
+                                <p class="text-base text-gray-900 font-bold"
+                                   th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd HH:mm') : '-'}">
+                                    2026-04-20 19:00
+                                </p>
+                            </div>
+
+                            <div>
+                                <h3 class="text-sm font-bold text-gray-600 mb-2">강의 종료 일시</h3>
+                                <p class="text-base text-gray-900 font-bold"
+                                   th:text="${liveCourse.endAt != null ? #temporals.format(liveCourse.endAt, 'yyyy-MM-dd HH:mm') : '-'}">
+                                    2026-04-20 21:00
+                                </p>
+                            </div>
+                        </div>
+
+                        <div>
+                            <h3 class="text-sm font-bold text-gray-600 mb-2">예약 시작 일시</h3>
+                            <p class="text-base text-gray-900 font-bold"
+                               th:text="${liveCourse.reservationStartAt != null ? #temporals.format(liveCourse.reservationStartAt, 'yyyy-MM-dd HH:mm') : '-'}">
+                                2026-04-18 09:00
+                            </p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-sm font-bold text-gray-600 mb-2">강의 상태</h3>
+
+                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
+                                  class="px-3 py-1 bg-yellow-100 text-yellow-700 rounded-full text-sm font-bold">
+                                승인 대기
+                            </span>
+
+                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
+                                  class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-bold">
+                                승인 완료
+                            </span>
+
+                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'REJECTED'}"
+                                  class="px-3 py-1 bg-red-100 text-red-700 rounded-full text-sm font-bold">
+                                반려됨
+                            </span>
+
+                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'IN_PROGRESS'}"
+                                  class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
+                                방송 중
+                            </span>
+
+                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'ENDED'}"
+                                  class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
+                                종료됨
+                            </span>
+
+                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'CANCELLED'}"
+                                  class="px-3 py-1 bg-orange-100 text-orange-700 rounded-full text-sm font-bold">
+                                요청 취소
+                            </span>
+
+                            <span th:if="${liveCourse.status == null}"
+                                  class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
+                                상태 없음
+                            </span>
+                        </div>
+
+                        <div>
+                            <h3 class="text-sm font-bold text-gray-600 mb-2">강의 내용</h3>
+                            <p class="text-base text-gray-700 leading-relaxed font-medium whitespace-pre-line"
+                               th:text="${liveCourse.description}">
+                                실시간 강의 설명
+                            </p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-sm font-bold text-gray-600 mb-2">방송 URL</h3>
+                            <a th:if="${liveCourse.streamingUrl != null and !#strings.isEmpty(liveCourse.streamingUrl)}"
+                               th:href="${liveCourse.streamingUrl}"
+                               th:text="${liveCourse.streamingUrl}"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-base text-blue-600 hover:text-blue-700 font-bold break-all">
+                                https://...
+                            </a>
+
+                            <p th:if="${liveCourse.streamingUrl == null or #strings.isEmpty(liveCourse.streamingUrl)}"
+                               class="text-base text-gray-400 font-bold">
+                                등록된 방송 URL이 없습니다
+                            </p>
+                        </div>
+
+                        <div>
+                            <h3 class="text-sm font-bold text-gray-600 mb-2">생성일</h3>
+                            <p class="text-base text-gray-900 font-medium"
+                               th:text="${liveCourse.createdAt != null ? #temporals.format(liveCourse.createdAt, 'yyyy-MM-dd') : '-'}">
+                                2026-04-01
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="lg:col-span-1">
+                <div class="bg-white border-2 border-gray-200 rounded-2xl p-6 shadow-sm sticky top-24">
+                    <h2 class="text-xl font-black text-gray-900 mb-6">강의 상세</h2>
+
+                    <div class="space-y-4">
+                        <div class="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
+                            <div class="w-10 h-10 bg-blue-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                                <i class="fa-solid fa-calendar-check text-blue-600"></i>
+                            </div>
+
+                            <div class="flex-1 min-w-0">
+                                <p class="text-xs font-bold text-gray-600 mb-1">예약 일시</p>
+                                <p class="text-sm font-black text-gray-900"
+                                   th:text="${liveCourse.reservationStartAt != null ? #temporals.format(liveCourse.reservationStartAt, 'yyyy-MM-dd HH:mm') : '-'}">
+                                    2026-04-18 09:00
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
+                            <div class="w-10 h-10 bg-green-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                                <i class="fa-solid fa-users text-green-600"></i>
+                            </div>
+
+                            <div class="flex-1 min-w-0">
+                                <p class="text-xs font-bold text-gray-600 mb-1">예약 현황</p>
+
+                                <p class="text-sm font-black text-gray-900">
+                                    <span th:text="${liveCourse.currentCount}">0</span>/<span th:text="${liveCourse.maxCapacity}">0</span>명
+                                </p>
+
+                                <div class="mt-2 w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+                                    <div class="bg-gradient-to-r from-green-500 to-green-600 h-2 rounded-full transition-all"
+                                         th:style="${liveCourse.maxCapacity > 0 ? 'width:' + (liveCourse.currentCount * 100 / liveCourse.maxCapacity) + '%' : 'width:0%'}">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
+                            <div class="w-10 h-10 bg-purple-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                                <i class="fa-solid fa-clock text-purple-600"></i>
+                            </div>
+
+                            <div class="flex-1 min-w-0">
+                                <p class="text-xs font-bold text-gray-600 mb-1">정원</p>
+                                <p class="text-sm font-black text-gray-900">
+                                    <span th:text="${liveCourse.maxCapacity}">0</span>명
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
+                            <div class="w-10 h-10 bg-orange-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                                <i class="fa-solid fa-video text-orange-600"></i>
+                            </div>
+
+                            <div class="flex-1 min-w-0">
+                                <p class="text-xs font-bold text-gray-600 mb-1">강의 시작</p>
+                                <p class="text-sm font-black text-gray-900"
+                                   th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd HH:mm') : '-'}">
+                                    2026-04-20 19:00
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="tab-reservations" class="tab-panel">
+        <div class="bg-white border-2 border-gray-200 rounded-2xl p-8 shadow-sm">
+            <div class="flex items-center justify-between mb-6">
+                <h2 class="text-2xl font-black text-gray-900">
+                    예약생 목록
+                    <span class="text-blue-600">
+                        (<span th:text="${reservations != null ? #lists.size(reservations) : 0}">0</span>명)
+                    </span>
+                </h2>
+            </div>
+
+            <div th:if="${reservations != null and not #lists.isEmpty(reservations)}" class="space-y-3">
+                <div th:each="reservation : ${reservations}"
+                     class="bg-gray-50 border-2 border-gray-200 rounded-xl p-5">
+                    <div class="flex items-center justify-between">
+                        <div class="flex-1 min-w-0">
+                            <div class="flex items-center gap-3 mb-2">
+                                <h3 class="text-lg font-black text-gray-900"
+                                    th:text="${reservation.name}">
+                                    예약자 이름
+                                </h3>
+
+                                <span th:if="${reservation.status != null and reservation.status.name() == 'RESERVED'}"
+                                      class="px-2.5 py-1 bg-green-100 text-green-700 rounded-full text-xs font-bold">
+                                    예약 완료
+                                </span>
+
+                                <span th:if="${reservation.status != null and reservation.status.name() == 'CANCELED'}"
+                                      class="px-2.5 py-1 bg-red-100 text-red-700 rounded-full text-xs font-bold">
+                                    취소됨
+                                </span>
+
+                                <span th:if="${reservation.status == null}"
+                                      class="px-2.5 py-1 bg-gray-100 text-gray-700 rounded-full text-xs font-bold">
+                                    상태 없음
+                                </span>
+                            </div>
+
+                            <div class="flex flex-wrap items-center gap-4 text-sm">
+                                <div class="flex items-center gap-2">
+                                    <i class="fa-solid fa-envelope text-gray-500 text-xs"></i>
+                                    <span class="text-gray-600 font-medium"
+                                          th:text="${reservation.email}">
+                                        user@example.com
+                                    </span>
+                                </div>
+
+                                <div class="flex items-center gap-2">
+                                    <i class="fa-solid fa-calendar text-gray-500 text-xs"></i>
+                                    <span class="text-gray-600 font-medium">
+                                        예약일:
+                                        <span th:text="${reservation.reservedAt != null ? #temporals.format(reservation.reservedAt, 'yyyy-MM-dd HH:mm') : '-'}">
+                                            2026-04-18 10:00
+                                        </span>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div th:if="${reservations == null or #lists.isEmpty(reservations)}" class="text-center py-16">
+                <i class="fa-solid fa-users text-gray-300 text-5xl mb-4 block"></i>
+                <p class="text-gray-500 font-bold">예약한 수강생이 없습니다</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    function switchTab(tab) {
+        ['info', 'reservations'].forEach(t => {
+            document.getElementById('tab-' + t).classList.remove('active');
+
+            const btn = document.getElementById('tab-btn-' + t);
+            btn.className = 'px-6 py-3 font-bold transition-all text-gray-600 hover:text-gray-900';
+        });
+
+        document.getElementById('tab-' + tab).classList.add('active');
+
+        const activeBtn = document.getElementById('tab-btn-' + tab);
+        activeBtn.className = 'px-6 py-3 font-bold transition-all text-blue-600 border-b-2 border-blue-600 -mb-[2px]';
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 강사 권한의 실시간 강의 상세 조회 기능 추가
- 실시간 강의 상세 조회 Response DTO 및 Service/Controller 로직 구현
- 실시간 강의 상세 조회 Thymeleaf 페이지 추가

## 💡 어떤 기능인가요?
- 강사가 본인이 등록한 실시간 강의의 상세 정보를 조회할 수 있는 기능
- 내 강의 관리 페이지에서 실시간 강의 조회 버튼 클릭 시 상세 페이지로 이동하여 강의 정보, 예약 일시, 강의 시작/종료 일시, 예약 현황, 정원, 방송 URL 등을 확인하는 기능
- 관리자 권한 사용자는 강사 소유 여부와 관계없이 실시간 강의 상세 조회 가능

## ✨ 변경 사항 (Changes)
- `InstructorLiveDetailResponse` DTO 추가
- `LiveLectureService`에 실시간 강의 상세 조회 로직 추가
- 실시간 강의 존재 여부 검증 추가
- 강사/관리자 권한 검증 추가
- 관리자 외 사용자의 실시간 강의 소유자 검증 추가
- `InstLiveController`에 상세 조회 엔드포인트 추가
- `GET /instructor/live-lecture/{liveId}` 추가
- `liveLectureDetail.html` 상세 조회 페이지 추가
- 강사 공통 헤더 적용
- 상세 페이지 상태 배지 렌더링 추가
- 상세 페이지 표시 항목 추가
  - 실시간 강의 상태
  - 실시간 강의 제목
  - 실시간 강의 설명
  - 예약 시작 일시
  - 강의 시작 일시
  - 강의 종료 일시
  - 방송 URL
  - 현재 예약 수
  - 총 정원
  - 생성일
- 강의 상세 카드 내 `강의 일시` 항목을 `예약 일시`로 변경
- 이미지/썸네일 영역 제거
- 예약생 조회 탭은 추후 구현을 위해 빈 목록으로 렌더링 처리

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [x] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 강사 계정으로 `/instructor/course-management` 페이지 접근 확인
- [x] 실시간 강의 목록에서 조회 버튼 클릭 시 상세 페이지 이동 확인
- [x] `/instructor/live-lecture/{liveId}` 상세 조회 페이지 렌더링 확인
- [x] 본인이 등록한 실시간 강의 상세 조회 성공 확인
- [x] 실시간 강의 제목 표시 확인
- [x] 실시간 강의 상태 배지 표시 확인
- [x] 예약 시작 일시 표시 확인
- [x] 강의 시작/종료 일시 표시 확인
- [x] 현재 예약 수 / 총 정원 표시 확인
- [x] 방송 URL 표시 확인
- [x] 예약생 목록이 없는 경우 empty state 표시 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 상세 조회는 강사 본인이 등록한 실시간 강의만 조회할 수 있도록 소유자 검증을 추가했습니다.
- 관리자 권한은 운영 목적상 소유자 검증 없이 상세 조회가 가능하도록 처리했습니다.
- 예약생 조회 탭은 추후 예약생 목록 조회 기능과 연결할 예정이며, 현재는 빈 목록으로 렌더링되도록 처리했습니다.
- 첨부 이미지/썸네일 영역은 기획 수정에 따라 제거했습니다.
- 상세 카드의 `강의 일시`는 요청사항에 맞춰 `예약 일시`로 변경했습니다.

## ✅ 체크 리스트
- [ ] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [ ] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [ ] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때 해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #145 
