### PR TITLE
실시간 강의 수정 기능 구현

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
@@ -8,6 +8,7 @@ import com.wanted.naeil.global.auth.model.dto.AuthDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -110,6 +111,13 @@ public class InstLiveController {
         return mv;
     }
 
+    /**
+     * 강사 - 실시간 강의 상세 조회
+     * @param authDetails : 세션 로그인 정보
+     * @param liveId : 실시간 강의 번호
+     * @param mv : response 값 및 html
+     * @return : html
+     */
     @GetMapping("/live-lecture/{liveId}")
     public ModelAndView getInstructorLiveLectureDetail(
             @AuthenticationPrincipal AuthDetails authDetails,
@@ -132,5 +140,54 @@ public class InstLiveController {
         mv.setViewName("live/liveLectureDetail");
 
         return mv;
+    }
+
+    @GetMapping("/live-lecture/{liveId}/edit")
+    public ModelAndView editLiveLecture(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long liveId,
+            ModelAndView mv
+    ) {
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        Long instructorId = authDetails.getLoginUserDTO().getUserId();
+
+        InstructorLiveDetailResponse response =
+                liveLectureService.getInstructorLiveLectureDetail(instructorId, liveId);
+
+        mv.addObject("user", authDetails.getLoginUserDTO());
+        mv.addObject("liveCourse", response);
+        mv.setViewName("live/liveLectureEdit");
+
+        return mv;
+    }
+
+    @PatchMapping("/live-lecture/{liveId}")
+    public ResponseEntity<String> updateInstructorLiveLecture(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long liveId,
+            @Valid @ModelAttribute CreateLiveLectureRequest request
+    ) {
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        Long instructorId = authDetails.getLoginUserDTO().getUserId();
+
+        log.info("[LiveLectureUpdate] 실시간 강의 수정 요청 - instructorId: {}, liveId: {}",
+                instructorId, liveId);
+
+        try {
+            liveLectureService.updateInstructorLiveLecture(instructorId, liveId, request);
+            return ResponseEntity.ok("실시간 강의 정보가 수정되었습니다.");
+        } catch (IllegalArgumentException e) {
+            log.warn("[LiveLectureUpdate] 잘못된 수정 요청 - liveId: {}, message: {}", liveId, e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (IllegalStateException e) {
+            log.warn("[LiveLectureUpdate] 수정 불가 상태 - liveId: {}, message: {}", liveId, e.getMessage());
+            return ResponseEntity.status(409).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/live/entity/LiveLecture.java
+++ b/src/main/java/com/wanted/naeil/domain/live/entity/LiveLecture.java
@@ -53,6 +53,8 @@ public class LiveLecture extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private LiveLectureStatus status; // RESERVED, CANCELED
 
+    // 비지니스 메서드
+
     @Builder
     public LiveLecture(User instructor, String title, String description, int maxCapacity,
                        LocalDateTime reservationStartAt,
@@ -81,5 +83,23 @@ public class LiveLecture extends BaseTimeEntity {
     // 상태 변경 메서드
     public void changeStatus(LiveLectureStatus status) {
         this.status = status;
+    }
+
+    // 수정 업데이트
+    public void update( String title, String description, int maxCapacity,
+            LocalDateTime reservationStartAt, LocalDateTime startAt,
+            LocalDateTime endAt, String streamingUrl
+    ) {
+        if (maxCapacity < this.currentCount) {
+            throw new IllegalArgumentException("수강 정원은 현재 예약 수보다 작을 수 없습니다.");
+        }
+
+        this.title = title;
+        this.description = description;
+        this.maxCapacity = maxCapacity;
+        this.reservationStartAt = reservationStartAt;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.streamingUrl = streamingUrl;
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -6,6 +6,7 @@ import com.wanted.naeil.domain.live.dto.request.CreateLiveLectureRequest;
 import com.wanted.naeil.domain.live.dto.response.InstructorLiveDetailResponse;
 import com.wanted.naeil.domain.live.dto.response.InstructorLiveLectureResponse;
 import com.wanted.naeil.domain.live.entity.LiveLecture;
+import com.wanted.naeil.domain.live.entity.enums.LiveLectureStatus;
 import com.wanted.naeil.domain.live.repository.LiveLectureRepository;
 import com.wanted.naeil.domain.user.entity.User;
 import com.wanted.naeil.domain.user.entity.enums.Role;
@@ -42,25 +43,8 @@ public class LiveLectureService {
             throw new AccessDeniedException("강사 권한이 있는 사용자만 강의를 등록할 수 있습니다.");
         }
 
-        // 제목 체크
-        if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
-            throw new IllegalArgumentException("강의 제목 필수 입력 값입니다.");
-        }
-
-        // 설명 체크
-        if (request.getDescription() == null || request.getDescription().trim().isEmpty()) {
-            throw new IllegalArgumentException("강의 설명은 필수 입력 값입니다.");
-        }
-
-        // 수강 정원 체크
-        if (request.getMaxCapacity() == null || request.getMaxCapacity() < 1) {
-            throw new IllegalArgumentException("올바른 수강 정원 값을 입력해주세요.");
-        }
-
-        // 방송 url 체크
-        if (request.getStreamingUrl() == null || request.getStreamingUrl().trim().isEmpty()) {
-            throw new IllegalArgumentException("방송 URL은 필수 입력 값 입니다.");
-        }
+        // 필수값 확인 메서드 공동 메서드로 변경
+        validateLiveLectureRequiredValues(request);
 
         // 시간 관련 검증
         validateLiveLectureTime(request);
@@ -120,6 +104,47 @@ public class LiveLectureService {
         return InstructorLiveDetailResponse.of(liveLecture);
     }
 
+    // 강사 - 실시간 강의 수정
+    @Transactional
+    public void updateInstructorLiveLecture(Long instructorId, Long liveId, @Valid CreateLiveLectureRequest request) {
+
+        log.info("[실시간 강의] 실시간 강의 수정 Service 로직 시작!");
+
+        User instructor = userRepository.findById(instructorId)
+                .orElseThrow(() -> new IllegalArgumentException("강사 정보를 찾을 수 없습니다. ID: " + instructorId));
+
+        LiveLecture liveLecture = liveLectureRepository.findById(liveId)
+                .orElseThrow(() -> new IllegalArgumentException("실시간 강의를 찾을 수 없습니다. ID: " + liveId));
+
+        // 강사 본인 or 관리자만 처리
+        validateLiveLectureOwnerOrAdmin(instructor, liveLecture);
+
+        // 승인 대기 상태일 때만 수정 가능
+        LiveLectureStatus status = liveLecture.getStatus();
+
+        if (status != LiveLectureStatus.PENDING) {
+            throw new IllegalStateException("승인 대기 상태만 수정할 수 있습니다.");
+        }
+
+        // 필수 값 확인
+        validateLiveLectureRequiredValues(request);
+
+        // 시간 검증
+        validateLiveLectureTime(request);
+
+        liveLecture.update(
+                request.getTitle().trim(),
+                request.getDescription().trim(),
+                request.getMaxCapacity(),
+                request.getReservationStartAt(),
+                request.getStartAt(),
+                request.getEndAt(),
+                request.getStreamingUrl().trim()
+        );
+
+        log.info("[LiveLectureUpdate] 실시간 강의 수정 완료 - liveId: {}", liveId);
+    }
+
 
     // ====== 내부 편의 메서드 =======
     private void validateLiveLectureTime(CreateLiveLectureRequest request) {
@@ -156,6 +181,29 @@ public class LiveLectureService {
             throw new IllegalArgumentException("예약 시작 일시는 강의 시작 일시보다 빨라야 합니다.");
         }
     }
+
+    private void validateLiveLectureRequiredValues(CreateLiveLectureRequest request) {
+        if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
+            throw new IllegalArgumentException("실시간 강의 제목은 필수 입력 값입니다.");
+        }
+
+        if (request.getDescription() == null || request.getDescription().trim().isEmpty()) {
+            throw new IllegalArgumentException("실시간 강의 설명은 필수 입력 값입니다.");
+        }
+
+        if (request.getMaxCapacity() == null || request.getMaxCapacity() < 1) {
+            throw new IllegalArgumentException("수강 정원은 1명 이상이어야 합니다.");
+        }
+
+        if (request.getMaxCapacity() > 100) {
+            throw new IllegalArgumentException("신청 가능한 최대 수강 정원은 100명입니다.");
+        }
+
+        if (request.getStreamingUrl() == null || request.getStreamingUrl().trim().isEmpty()) {
+            throw new IllegalArgumentException("방송 URL은 필수 입력 값입니다.");
+        }
+    }
+
 
     private void validateLiveLectureOwnerOrAdmin(User user, LiveLecture liveLecture) {
         if (user.getRole() == Role.ADMIN) {

--- a/src/main/java/com/wanted/naeil/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/naeil/global/error/GlobalExceptionHandler.java
@@ -41,6 +41,7 @@ public class GlobalExceptionHandler {
         mv.setViewName(DEFAULT_ERROR_VIEW);
         return mv;
     }
+
     // 404 에러, 데이터 not found
     @ExceptionHandler(NoSuchElementException.class)
     protected ModelAndView handleNoSuchElementException(NoSuchElementException e) {
@@ -74,6 +75,7 @@ public class GlobalExceptionHandler {
         mv.setViewName(DEFAULT_ERROR_VIEW);
         return mv;
     }
+
 
     // 403 에러, 권한 없음 (글 수정/삭제 시 본인이 아닌 경우)
     @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/resources/templates/course/InstructorCourseManagement.html
+++ b/src/main/resources/templates/course/InstructorCourseManagement.html
@@ -280,8 +280,9 @@
               <i class="fa-regular fa-eye"></i>
             </a>
 
-            <a th:if="${liveCourse.status != null and (liveCourse.status.name() == 'PENDING' or liveCourse.status.name() == 'APPROVED' or liveCourse.status.name() == 'REJECTED' or liveCourse.status.name() == 'CANCELLED')}"
+            <a th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
                th:href="@{/instructor/live-lecture/{id}/edit(id=${liveCourse.liveId})}"
+               href="/instructor/live-lecture/1/edit"
                class="flex h-12 w-12 items-center justify-center rounded-xl border-2 border-green-300 text-green-600 transition-all hover:bg-green-50"
                title="수정">
               <i class="fa-regular fa-pen-to-square"></i>

--- a/src/main/resources/templates/live/liveLectureDetail.html
+++ b/src/main/resources/templates/live/liveLectureDetail.html
@@ -86,7 +86,7 @@
                 </p>
             </div>
 
-            <a th:if="${liveCourse.status != null and (liveCourse.status.name() == 'PENDING' or liveCourse.status.name() == 'APPROVED' or liveCourse.status.name() == 'REJECTED' or liveCourse.status.name() == 'CANCELLED')}"
+            <a th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
                th:href="@{/instructor/live-lecture/{id}/edit(id=${liveCourse.liveId})}"
                href="/instructor/live-lecture/1/edit"
                class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-xl transition-all font-bold">

--- a/src/main/resources/templates/live/liveLectureEdit.html
+++ b/src/main/resources/templates/live/liveLectureEdit.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>실시간 강의 수정 | Nae-Il</title>
+
+  <meta name="_csrf" th:content="${_csrf != null ? _csrf.token : ''}">
+  <meta name="_csrf_header" th:content="${_csrf != null ? _csrf.headerName : ''}">
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
+  <script src="https://unpkg.com/lucide@latest"></script>
+
+  <style>
+    body {
+      background-color: #f8fafc;
+    }
+  </style>
+</head>
+
+<body>
+<div th:replace="~{fragments/instructorHeader :: instructorHeader}"></div>
+
+<div class="max-w-7xl mx-auto px-6 py-12"
+     th:attr="data-live-id=${liveCourse.liveId}">
+
+  <div class="mb-10">
+    <a th:href="@{/instructor/live-lecture/{id}(id=${liveCourse.liveId})}"
+       href="/instructor/course-management"
+       class="inline-flex items-center gap-3 text-gray-600 hover:text-blue-600 transition-colors mb-6">
+      <i class="fa-solid fa-arrow-left text-sm"></i>
+      <span class="text-sm font-bold">이전으로</span>
+    </a>
+
+    <div class="flex items-end justify-between gap-6">
+      <div>
+        <h1 class="text-5xl font-black text-gray-900 mb-4">실시간 강의 수정</h1>
+        <p class="text-2xl text-gray-600 font-medium">등록한 실시간 강의 정보를 수정할 수 있습니다</p>
+      </div>
+
+      <span th:if="${liveCourse.status != null}"
+            class="px-4 py-2 rounded-xl text-sm font-black"
+            th:classappend="${liveCourse.status.name() == 'PENDING'} ? ' bg-yellow-100 text-yellow-700' :
+                                  (${liveCourse.status.name() == 'APPROVED'} ? ' bg-green-100 text-green-700' :
+                                  (${liveCourse.status.name() == 'REJECTED'} ? ' bg-red-100 text-red-700' :
+                                  (${liveCourse.status.name() == 'IN_PROGRESS'} ? ' bg-blue-100 text-blue-700' :
+                                  (${liveCourse.status.name() == 'ENDED'} ? ' bg-gray-100 text-gray-700' :
+                                  (${liveCourse.status.name() == 'CANCELLED'} ? ' bg-orange-100 text-orange-700' :
+                                                                                ' bg-gray-100 text-gray-700')))))"
+            th:text="${liveCourse.statusDescription}">
+                상태
+            </span>
+    </div>
+  </div>
+
+  <div th:if="${errorMessage != null}"
+       class="mb-6 rounded-2xl border-2 border-red-200 bg-red-50 px-6 py-4 text-red-700 font-bold">
+    <span th:text="${errorMessage}">실시간 강의 수정 중 오류가 발생했습니다.</span>
+  </div>
+
+  <form id="liveLectureEditForm"
+        class="space-y-8"
+        onsubmit="return false;">
+
+    <input type="hidden"
+           th:name="${_csrf != null ? _csrf.parameterName : '_csrf'}"
+           th:value="${_csrf != null ? _csrf.token : ''}"/>
+
+    <section class="bg-white border-2 border-gray-200 rounded-2xl p-10 shadow-lg">
+      <h2 class="text-3xl font-black text-gray-900 mb-8">실시간 강의 정보</h2>
+
+      <div class="space-y-7">
+        <div>
+          <label for="title" class="block text-sm font-black text-gray-700 mb-3">
+            강의명 <span class="text-red-500">*</span>
+          </label>
+          <input type="text"
+                 id="title"
+                 name="title"
+                 th:value="${liveCourse.title}"
+                 required
+                 maxlength="100"
+                 placeholder="강의명을 입력하세요"
+                 class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900 placeholder:text-gray-400"/>
+        </div>
+
+        <div>
+          <label for="description" class="block text-sm font-black text-gray-700 mb-3">
+            강의 설명 <span class="text-red-500">*</span>
+          </label>
+          <textarea id="description"
+                    name="description"
+                    rows="6"
+                    required
+                    placeholder="강의 설명을 입력하세요"
+                    class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none resize-none font-bold text-gray-900 placeholder:text-gray-400"
+                    th:text="${liveCourse.description}"></textarea>
+        </div>
+
+        <div>
+          <label for="maxCapacity" class="block text-sm font-black text-gray-700 mb-3">
+            수강 정원 <span class="text-red-500">*</span>
+          </label>
+          <input type="number"
+                 id="maxCapacity"
+                 name="maxCapacity"
+                 min="1"
+                 max="100"
+                 required
+                 th:value="${liveCourse.maxCapacity}"
+                 placeholder="수강 정원을 입력하세요"
+                 class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900 placeholder:text-gray-400"/>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label for="startAt" class="block text-sm font-black text-gray-700 mb-3">
+              강의 시작 일시 <span class="text-red-500">*</span>
+            </label>
+            <input type="datetime-local"
+                   id="startAt"
+                   name="startAt"
+                   required
+                   th:value="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd''T''HH:mm') : ''}"
+                   class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900"/>
+          </div>
+
+          <div>
+            <label for="endAt" class="block text-sm font-black text-gray-700 mb-3">
+              강의 종료 일시 <span class="text-red-500">*</span>
+            </label>
+            <input type="datetime-local"
+                   id="endAt"
+                   name="endAt"
+                   required
+                   th:value="${liveCourse.endAt != null ? #temporals.format(liveCourse.endAt, 'yyyy-MM-dd''T''HH:mm') : ''}"
+                   class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900"/>
+          </div>
+        </div>
+
+        <div>
+          <label for="reservationStartAt" class="block text-sm font-black text-gray-700 mb-3">
+            예약 시작 일시 <span class="text-red-500">*</span>
+          </label>
+          <input type="datetime-local"
+                 id="reservationStartAt"
+                 name="reservationStartAt"
+                 required
+                 th:value="${liveCourse.reservationStartAt != null ? #temporals.format(liveCourse.reservationStartAt, 'yyyy-MM-dd''T''HH:mm') : ''}"
+                 class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900"/>
+        </div>
+
+        <div>
+          <label for="streamingUrl" class="block text-sm font-black text-gray-700 mb-3">
+            방송 URL <span class="text-red-500">*</span>
+          </label>
+          <input type="url"
+                 id="streamingUrl"
+                 name="streamingUrl"
+                 required
+                 maxlength="500"
+                 th:value="${liveCourse.streamingUrl}"
+                 placeholder="https://..."
+                 class="w-full px-5 py-4 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none font-bold text-gray-900 placeholder:text-gray-400"/>
+        </div>
+      </div>
+    </section>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 pb-6">
+      <a th:href="@{/instructor/live-lecture/{id}(id=${liveCourse.liveId})}"
+         href="/instructor/course-management"
+         class="flex items-center justify-center px-10 py-4 border-2 border-gray-300 rounded-xl hover:bg-gray-50 transition-all font-black text-gray-700 text-lg">
+        취소
+      </a>
+
+      <button type="button"
+              onclick="submitLiveLectureEdit()"
+              class="flex items-center justify-center px-10 py-4 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-xl transition-all font-black text-lg">
+        수정 저장
+      </button>
+    </div>
+  </form>
+</div>
+
+<script>
+  lucide.createIcons();
+
+  const root = document.querySelector('[data-live-id]');
+  const liveId = root.dataset.liveId;
+
+  function getCsrfHeaders() {
+    const csrfToken = document.querySelector('meta[name="_csrf"]')?.content;
+    const csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.content;
+
+    if (!csrfToken || !csrfHeader) {
+      return {};
+    }
+
+    return {
+      [csrfHeader]: csrfToken
+    };
+  }
+
+  function validateLiveLectureEditForm() {
+    const title = document.getElementById('title').value.trim();
+    const description = document.getElementById('description').value.trim();
+    const startAt = document.getElementById('startAt').value;
+    const endAt = document.getElementById('endAt').value;
+    const reservationStartAt = document.getElementById('reservationStartAt').value;
+    const streamingUrl = document.getElementById('streamingUrl').value.trim();
+    const maxCapacity = Number(document.getElementById('maxCapacity').value);
+
+    if (!title) {
+      alert('강의명을 입력해주세요.');
+      return false;
+    }
+
+    if (!description) {
+      alert('강의 설명을 입력해주세요.');
+      return false;
+    }
+
+    if (maxCapacity < 1 || maxCapacity > 100) {
+      alert('수강 정원은 1명 이상 100명 이하로 입력해주세요.');
+      return false;
+    }
+
+    if (!startAt || !endAt || !reservationStartAt) {
+      alert('강의 일시와 예약 시작 일시를 입력해주세요.');
+      return false;
+    }
+
+    if (!streamingUrl) {
+      alert('방송 URL을 입력해주세요.');
+      return false;
+    }
+
+    const startDate = new Date(startAt);
+    const endDate = new Date(endAt);
+    const reservationDate = new Date(reservationStartAt);
+    const now = new Date();
+
+    if (startDate <= now) {
+      alert('강의 시작 일시는 현재 시간 이후여야 합니다.');
+      return false;
+    }
+
+    if (reservationDate <= now) {
+      alert('예약 시작 일시는 현재 시간 이후여야 합니다.');
+      return false;
+    }
+
+    if (endDate <= startDate) {
+      alert('강의 종료 일시는 강의 시작 일시보다 늦어야 합니다.');
+      return false;
+    }
+
+    if (reservationDate >= startDate) {
+      alert('예약 시작 일시는 강의 시작 일시보다 빨라야 합니다.');
+      return false;
+    }
+
+    return true;
+  }
+
+  async function submitLiveLectureEdit() {
+    if (!validateLiveLectureEditForm()) {
+      return;
+    }
+
+    const form = document.getElementById('liveLectureEditForm');
+    const formData = new FormData(form);
+
+    const response = await fetch(`/instructor/live-lecture/${liveId}`, {
+      method: 'PATCH',
+      headers: getCsrfHeaders(),
+      body: formData
+    });
+
+    const message = await response.text();
+
+    if (!response.ok) {
+      alert(message || '실시간 강의 수정에 실패했습니다.');
+      return;
+    }
+
+    alert(message || '실시간 강의 정보가 수정되었습니다.');
+    location.href = `/instructor/live-lecture/${liveId}`;
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 강사 권한의 실시간 강의 수정 페이지 조회 기능 추가
- 승인 대기 상태의 실시간 강의 정보 수정 기능 추가
- 실시간 강의 수정 시 권한, 상태, 날짜, 정원 검증 로직 추가

## 💡 어떤 기능인가요?
- 강사가 본인이 등록한 실시간 강의 중 승인 대기 상태인 강의를 수정할 수 있는 기능
- 실시간 강의 제목, 설명, 수강 정원, 예약 시작 일시, 강의 시작/종료 일시, 방송 URL을 수정하는 기능
- 승인 대기 상태가 아닌 실시간 강의는 수정할 수 없도록 제한하는 기능

## ✨ 변경 사항 (Changes)
- `GET /instructor/live-lecture/{liveId}/edit` 실시간 강의 수정 페이지 조회 기능 추가
- `PATCH /instructor/live-lecture/{liveId}` 실시간 강의 수정 요청 처리 기능 추가
- `LiveLectureService`에 실시간 강의 수정 비즈니스 로직 추가
- `LiveLecture` 엔티티에 실시간 강의 정보 수정 메서드 추가
- 강사 본인 또는 관리자만 수정 가능하도록 권한 검증 추가
- 실시간 강의 상태가 `PENDING`일 때만 수정 가능하도록 상태 검증 추가
- 예약 시작 일시, 강의 시작 일시, 강의 종료 일시 검증 추가
- 수강 정원이 현재 예약 수보다 작아지지 않도록 검증 추가
- 실시간 강의 수정 HTML 및 fetch 요청 처리 로직 추가
- **DB 스키마 변경:** 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [x] 버그 수정
- [ ] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 승인 대기 상태의 실시간 강의 수정 페이지 조회 확인
- [x] 실시간 강의 제목, 설명, 정원, 날짜, 방송 URL 수정 확인
- [x] 강사 본인이 아닌 실시간 강의 수정 요청 차단 확인
- [x] 승인 대기 상태가 아닌 실시간 강의 수정 요청 차단 확인
- [x] 예약 시작 일시가 현재 시간 이전인 경우 수정 실패 확인
- [x] 강의 종료 일시가 시작 일시보다 빠른 경우 수정 실패 확인
- [x] 현재 예약 수보다 작은 수강 정원으로 수정 시 실패 확인
- [x] 수정 실패 시 현재 페이지에서 에러 메시지 표시 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 실시간 강의 수정은 현재 정책상 `PENDING` 상태에서만 가능하도록 제한함
- `fetch(PATCH)` 기반 요청이므로 실패 시 에러 페이지 이동이 아닌 현재 페이지 alert 메시지로 안내하도록 구현함
- 예외 응답 처리는 우선 컨트롤러 단에서 처리하고, 추후 fetch 기반 요청이 많아질 경우 `GlobalExceptionHandler`에서 비동기 요청 분기 처리 방식으로 리팩토링 가능함

## ✅ 체크 리스트
- [x] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때 해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #151 
