### PR TITLE
실시간 강의 삭제, 승인 요청 상태 연동 처리

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/admin/repository/AdminApprovalRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/repository/AdminApprovalRepository.java
@@ -3,6 +3,7 @@ package com.wanted.naeil.domain.admin.repository;
 import com.wanted.naeil.domain.admin.entity.enums.ApprovalRequestType;
 import com.wanted.naeil.domain.admin.entity.enums.ApprovalStatus;
 import com.wanted.naeil.domain.admin.entity.AdminApproval;
+import com.wanted.naeil.domain.live.entity.LiveLecture;
 import com.wanted.naeil.domain.user.entity.InstructorApplications;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -20,4 +21,14 @@ public interface AdminApprovalRepository extends JpaRepository<AdminApproval, Lo
 
     // 승재 추가 : 강사 스스로 강사 신청 철회
     void deleteByInstructorApplications(InstructorApplications instructorApplications);
+
+    // 정수 추가 : 실시간 강의 삭제
+    void deleteByLecture(LiveLecture lecture);
+
+    // 정수 추가 : 강사가 등록 요청 취소 했을 때, 승인 테이블에 기록 삭제하기 위한 코드
+    void deleteByCourseIdAndRequestTypeAndStatus(
+            Long courseId,
+            ApprovalRequestType requestType,
+            ApprovalStatus status
+    );
 }

--- a/src/main/java/com/wanted/naeil/domain/admin/service/AdminApprovalService.java
+++ b/src/main/java/com/wanted/naeil/domain/admin/service/AdminApprovalService.java
@@ -123,7 +123,11 @@ public class AdminApprovalService {
         approval.reject(admin, rejectReason);
 
         switch (approval.getRequestType()) {
-            case COURSE_REGISTER, COURSE_DELETE -> {
+            case COURSE_REGISTER -> {
+                approval.getCourse().rejectRegistration();
+            }
+            case COURSE_DELETE -> {
+                // 삭제 요청 반려 시 코스는 기존 INACTIVE 상태 유지 비워놓음
             }
             case INSTRUCTOR_REGISTER -> {
                 approval.getInstructorApplications().reject(rejectReason);
@@ -132,6 +136,9 @@ public class AdminApprovalService {
             case LIVE_REGISTER -> {
                 approval.getLecture().changeStatus(LiveLectureStatus.REJECTED);
                 liveLectureRepository.save(approval.getLecture());
+            }
+            case SETTLEMENT_REGISTER -> {
+                // TODO : 정산 반려 정책 필요 시 추가
             }
         }
         courseApprovalRepository.save(approval);

--- a/src/main/java/com/wanted/naeil/domain/course/controller/UserCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/UserCourseController.java
@@ -28,7 +28,7 @@ public class UserCourseController {
 
         log.info("[Course] 전체 코스 목록 페이지 조회");
 
-        List<CourseListResponse> courses = courseService.findAllCourses();
+        List<CourseListResponse> courses = courseService.getAllCourses();
 
         mv.addObject("courses", courses);
         mv.addObject("categories", categoryRepository.findAll());

--- a/src/main/java/com/wanted/naeil/domain/course/entity/Course.java
+++ b/src/main/java/com/wanted/naeil/domain/course/entity/Course.java
@@ -92,4 +92,8 @@ public class Course extends BaseTimeEntity {
     public void requestRegistration() {
         this.status = CourseStatus.PENDING;
     }
+
+    public void rejectRegistration() {
+        this.status = CourseStatus.REJECTED;
+    }
 }

--- a/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
+++ b/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
@@ -47,7 +47,7 @@ public class CourseService {
     private final SectionService sectionService;
     private final ModelMapper modelMapper;
 
-    // 코스 생성 - 강사
+    // 코스 등록 요청 - 강사
     @Transactional
     public CreateCourseResponse createCourse(Long instructorId, CourseCreateRequest request) throws AccessDeniedException {
 
@@ -109,7 +109,14 @@ public class CourseService {
         log.info("[코스 생성] 코스가 정상적으로 등록 됐습니다. course_id: {}", savedCourse.getId());
 
 
-        // TODO : createSection() 만들어서 호출하기
+        // 강사 승인 테이블에 요청 로직
+        AdminApproval adminApproval = AdminApproval.builder()
+                .course(savedCourse)
+                .requestType(ApprovalRequestType.COURSE_REGISTER)
+                .build();
+
+        adminApprovalRepository.save(adminApproval);
+
         if (request.getSections() != null && !request.getSections().isEmpty()) {
             sectionService.registerSections(course, request.getSections());
         }
@@ -159,7 +166,7 @@ public class CourseService {
 
     // 강의 전체 조회 - 공통
     @Transactional(readOnly = true)
-    public List<CourseListResponse> findAllCourses() {
+    public List<CourseListResponse> getAllCourses() {
         return courseRepository.findAllWithStatus();
     }
 
@@ -261,26 +268,66 @@ public class CourseService {
         CourseStatus currentStatus = course.getStatus();
 
         if (currentStatus == CourseStatus.PENDING && nextStatus == CourseStatus.CANCELLED) {
+
+            log.info("[코스 상태 변경] 승인 대기 -> 취소됨 상태 변경 시작!");
+
+            // 승인 대기 -> 취소 했으니까, 관리자 승인 테이블 속 기록 삭제
+            adminApprovalRepository.deleteByCourseIdAndRequestTypeAndStatus(
+                    courseId,
+                    ApprovalRequestType.COURSE_REGISTER,
+                    ApprovalStatus.PENDING
+            );
+
             course.cancelRegistration();
 
-            log.info("[CourseRegistrationStatus] 강의 등록 요청 취소 완료 - instructorId: {}, courseId: {}",
+            log.info("[코스 상태 변경] 강의 등록 요청 취소 완료 - instructorId: {}, courseId: {}",
                     instructorId, courseId);
 
             return;
         }
 
-        if (currentStatus == CourseStatus.CANCELLED && nextStatus == CourseStatus.PENDING) {
+        if (currentStatus == CourseStatus.CANCELLED || currentStatus == CourseStatus.REJECTED
+                && nextStatus == CourseStatus.PENDING) {
+
+            log.info("[코스 상태 변경] 취소 / 반려 -> 승인대기 상태 변경 시작!");
+
+            // 승인 대기 테이블에 이미 존재하는지 검증
+            boolean alreadyRequested = adminApprovalRepository.existsByCourseIdAndRequestTypeAndStatus(
+                    courseId,
+                    ApprovalRequestType.COURSE_REGISTER,
+                    ApprovalStatus.PENDING
+            );
+
+            if (alreadyRequested) {
+                throw new IllegalStateException("이미 등록 승인 요청이 진행 중인 강의입니다.");
+            }
+
+            // 승인 요청 테이블에 새롭게 추가
+            AdminApproval approval = AdminApproval.builder()
+                    .course(course)
+                    .requestType(ApprovalRequestType.COURSE_REGISTER)
+                    .build();
+
+            adminApprovalRepository.save(approval);
+
+            // 코스 승인 대기 상태로 변경
             course.requestRegistration();
 
-            log.info("[CourseRegistrationStatus] 강의 등록 재요청 완료 - instructorId: {}, courseId: {}",
+            log.info("[코스 상태 변경] 강의 등록 재요청 완료 - instructorId: {}, courseId: {}",
                     instructorId, courseId);
             return;
         }
 
+        log.error("[코스 상태 변경] 🚨 코스 상태 변경 실패 ㅜ 에러가 발생했다..");
         throw new IllegalStateException("현재 상태에서는 요청한 등록 상태로 변경할 수 없습니다.");
     }
 
+    // 코스 삭제 요청
+    @Transactional
     public void requestCourseDelete(Long instructorId, Long courseId) {
+
+        log.info("[CourseDeleteRequest] 강의 삭제 요청 시작 - instructorId: {}, courseId: {}",
+                instructorId, courseId);
 
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 강의입니다."));

--- a/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
@@ -142,6 +142,13 @@ public class InstLiveController {
         return mv;
     }
 
+    /**
+     * 실시간 강의 수정 form 조회
+     * @param authDetails
+     * @param liveId
+     * @param mv
+     * @return
+     */
     @GetMapping("/live-lecture/{liveId}/edit")
     public ModelAndView editLiveLecture(
             @AuthenticationPrincipal AuthDetails authDetails,
@@ -164,6 +171,13 @@ public class InstLiveController {
         return mv;
     }
 
+    /**
+     * 실시간 강의 수정 기능
+     * @param authDetails
+     * @param liveId
+     * @param request : 수정 사항을 묶어놓은 request
+     * @return
+     */
     @PatchMapping("/live-lecture/{liveId}")
     public ResponseEntity<String> updateInstructorLiveLecture(
             @AuthenticationPrincipal AuthDetails authDetails,
@@ -187,6 +201,32 @@ public class InstLiveController {
             return ResponseEntity.badRequest().body(e.getMessage());
         } catch (IllegalStateException e) {
             log.warn("[LiveLectureUpdate] 수정 불가 상태 - liveId: {}, message: {}", liveId, e.getMessage());
+            return ResponseEntity.status(409).body(e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/live-lecture/{liveId}")
+    public ResponseEntity<String> deleteInstructorLiveLecture(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long liveId
+    ) {
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        Long instructorId = authDetails.getLoginUserDTO().getUserId();
+
+        log.info("[실시간 강의 삭제] 실시간 강의 삭제 요청 - instructorId: {}, liveId: {}",
+                instructorId, liveId);
+
+        try {
+            liveLectureService.deleteLiveLecture(instructorId, liveId);
+            return ResponseEntity.ok("실시간 강의가 삭제되었습니다.");
+        } catch (IllegalArgumentException e) {
+            log.warn("[실시간 강의 삭제] 잘못된 삭제 요청 - liveId: {}, message: {}", liveId, e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (IllegalStateException e) {
+            log.warn("[LiveLectureDelete] 삭제 불가 상태 - liveId: {}, message: {}", liveId, e.getMessage());
             return ResponseEntity.status(409).body(e.getMessage());
         }
     }

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -145,6 +145,36 @@ public class LiveLectureService {
         log.info("[LiveLectureUpdate] 실시간 강의 수정 완료 - liveId: {}", liveId);
     }
 
+    // 실시간 강의 삭제
+    @Transactional
+    public void deleteLiveLecture(Long instructorId, Long liveId) {
+
+        log.info("[실시간 강의] 실시간 강의 삭제 Service 로직 시작!");
+
+        User instructor = userRepository.findById(instructorId)
+                .orElseThrow(() -> new IllegalArgumentException("강사 정보를 찾을 수 없습니다. ID: " + instructorId));
+
+        LiveLecture liveLecture = liveLectureRepository.findById(liveId)
+                .orElseThrow(() -> new IllegalArgumentException("실시간 강의를 찾을 수 없습니다. ID: " + liveId));
+
+        // 강사 본인 or 관리자
+        validateLiveLectureOwnerOrAdmin(instructor, liveLecture);
+
+        // 승인 대기 or 반려 상태일 때만 삭제 가능
+        LiveLectureStatus status = liveLecture.getStatus();
+
+        if (status != LiveLectureStatus.PENDING && status != LiveLectureStatus.REJECTED) {
+            throw new IllegalStateException("승인 대기 또는 반려 상태의 실시간 강의만 삭제할 수 있습니다.");
+        }
+
+        // 관리자 승인 테이블 먼저 삭제
+        adminApprovalRepository.deleteByLecture(liveLecture);
+        // 실시간 강의 삭제
+        liveLectureRepository.delete(liveLecture);
+
+        log.info("[LiveLectureDelete] 실시간 강의 삭제 완료 - liveId: {}", liveId);
+    }
+
 
     // ====== 내부 편의 메서드 =======
     private void validateLiveLectureTime(CreateLiveLectureRequest request) {
@@ -203,7 +233,6 @@ public class LiveLectureService {
             throw new IllegalArgumentException("방송 URL은 필수 입력 값입니다.");
         }
     }
-
 
     private void validateLiveLectureOwnerOrAdmin(User user, LiveLecture liveLecture) {
         if (user.getRole() == Role.ADMIN) {

--- a/src/main/resources/templates/course/InstructorCourseManagement.html
+++ b/src/main/resources/templates/course/InstructorCourseManagement.html
@@ -98,7 +98,7 @@
                 반려
               </span>
 
-              <span th:if="${course.status != null and course.status.name() == 'CANCELLED'}"
+              <span th:if="${course.status != null and (course.status.name() == 'CANCELLED' or course.status.name() == 'REJECTED')}"
                     class="px-3 py-1 bg-orange-100 text-orange-700 rounded-full text-xs font-bold">
                 요청취소
               </span>
@@ -153,7 +153,7 @@
             </button>
 
             <button type="button"
-                    th:if="${course.status != null and course.status.name() == 'CANCELLED'}"
+                    th:if="${course.status != null and (course.status.name() == 'CANCELLED' or course.status.name() == 'REJECTED')}"
                     th:data-id="${course.courseId}"
                     th:data-title="${course.title}"
                     onclick="updateCourseRegistrationStatus(this, 'PENDING')"
@@ -181,7 +181,7 @@
     <div th:if="${courses == null or #lists.isEmpty(courses)}"
          class="bg-white rounded-3xl border-2 border-dashed border-gray-200 py-24 text-center">
       <div class="w-28 h-28 bg-gray-100 rounded-3xl flex items-center justify-center mx-auto mb-8">
-        <span class="text-5xl">📚</span>
+        <i class="fa-solid fa-book-open text-gray-400 text-5xl"></i>
       </div>
 
       <h3 class="text-3xl font-black text-gray-900 mb-4">등록된 강의가 없습니다</h3>
@@ -217,40 +217,40 @@
         <div class="flex items-center justify-between gap-6">
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-3 mb-3">
-          <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
-                class="px-3 py-1 bg-yellow-100 text-yellow-700 rounded-full text-sm font-bold">
-            승인 대기
-          </span>
+              <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
+                    class="px-3 py-1 bg-yellow-100 text-yellow-700 rounded-full text-sm font-bold">
+                승인 대기
+              </span>
 
               <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
                     class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-bold">
-            승인 완료
-          </span>
+                승인 완료
+              </span>
 
               <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'REJECTED'}"
                     class="px-3 py-1 bg-red-100 text-red-700 rounded-full text-sm font-bold">
-            반려됨
-          </span>
+                반려됨
+              </span>
 
               <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'IN_PROGRESS'}"
                     class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
-            방송 중
-          </span>
+                방송 중
+              </span>
 
               <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'ENDED'}"
                     class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
-            종료됨
-          </span>
+                종료됨
+              </span>
 
               <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'CANCELLED'}"
                     class="px-3 py-1 bg-orange-100 text-orange-700 rounded-full text-sm font-bold">
-            요청 취소
-          </span>
+                요청 취소
+              </span>
 
               <span th:if="${liveCourse.status == null}"
                     class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
-            상태 없음
-          </span>
+                상태 없음
+              </span>
             </div>
 
             <h3 class="text-xl font-black text-gray-900 mb-3 group-hover:text-blue-600 transition-colors truncate"
@@ -259,28 +259,39 @@
             </h3>
 
             <div class="flex items-center gap-4 text-sm">
-          <span class="font-bold text-gray-700">
-            <i class="fa-solid fa-calendar text-gray-500 mr-1"></i>
-            <span th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd HH:mm') : '-'}">
-              2026-04-20 19:00
-            </span>
-          </span>
+              <span class="font-bold text-gray-700">
+                <i class="fa-solid fa-calendar text-gray-500 mr-1"></i>
+                <span th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd HH:mm') : '-'}">
+                  2026-04-20 19:00
+                </span>
+              </span>
 
               <span class="font-bold text-gray-700">
-            <i class="fa-solid fa-users text-gray-500 mr-1"></i>
-            <span th:text="${liveCourse.currentCount}">0</span>/<span th:text="${liveCourse.maxCapacity}">0</span>명
-          </span>
+                <i class="fa-solid fa-users text-gray-500 mr-1"></i>
+                <span th:text="${liveCourse.currentCount}">0</span>/<span th:text="${liveCourse.maxCapacity}">0</span>명
+              </span>
             </div>
           </div>
 
           <div class="flex items-center gap-3">
+            <button type="button"
+                    th:if="${liveCourse.status != null and (liveCourse.status.name() == 'PENDING' or liveCourse.status.name() == 'REJECTED')}"
+                    th:data-id="${liveCourse.liveId}"
+                    th:data-title="${liveCourse.title}"
+                    onclick="deleteLiveLecture(this)"
+                    class="flex h-12 w-12 items-center justify-center rounded-xl border-2 border-red-300 text-red-600 transition-all hover:bg-red-50"
+                    title="삭제">
+              <i class="fa-regular fa-trash-can"></i>
+            </button>
+
             <a th:href="@{/instructor/live-lecture/{id}(id=${liveCourse.liveId})}"
+               href="/instructor/live-lecture/1"
                class="flex h-12 w-12 items-center justify-center rounded-xl border-2 border-blue-300 text-blue-600 transition-all hover:bg-blue-50"
                title="조회">
               <i class="fa-regular fa-eye"></i>
             </a>
 
-            <a th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
+            <a th:if="${liveCourse.status != null and (liveCourse.status.name() == 'PENDING' or liveCourse.status.name() == 'REJECTED')}"
                th:href="@{/instructor/live-lecture/{id}/edit(id=${liveCourse.liveId})}"
                href="/instructor/live-lecture/1/edit"
                class="flex h-12 w-12 items-center justify-center rounded-xl border-2 border-green-300 text-green-600 transition-all hover:bg-green-50"
@@ -299,7 +310,7 @@
             </button>
 
             <button type="button"
-                    th:if="${liveCourse.status != null and liveCourse.status.name() == 'CANCELLED'}"
+                    th:if="${liveCourse.status != null and (liveCourse.status.name() == 'CANCELLED' or liveCourse.status.name() == 'REJECTED')}"
                     th:data-id="${liveCourse.liveId}"
                     th:data-title="${liveCourse.title}"
                     onclick="updateLiveLectureRegistrationStatus(this, 'PENDING')"
@@ -307,21 +318,10 @@
                     title="등록 요청">
               등록 요청
             </button>
-
-            <button type="button"
-                    th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
-                    th:data-id="${liveCourse.liveId}"
-                    th:data-title="${liveCourse.title}"
-                    onclick="openDeleteLiveModal(this)"
-                    class="flex h-12 w-12 items-center justify-center rounded-xl border-2 border-red-300 text-red-600 transition-all hover:bg-red-50"
-                    title="삭제 요청">
-              <i class="fa-regular fa-trash-can"></i>
-            </button>
           </div>
         </div>
       </div>
     </div>
-
 
     <div th:if="${liveCourses == null or #lists.isEmpty(liveCourses)}"
          class="bg-white rounded-3xl border-2 border-dashed border-gray-200 py-24 text-center">
@@ -384,12 +384,8 @@
     </div>
 
     <div class="mb-6 rounded-xl border-2 border-gray-200 bg-gray-50 p-4">
-      <p class="text-sm font-bold text-gray-800">
-        삭제 요청은 관리자 승인 후 처리됩니다.
-      </p>
-      <p class="mt-1 text-sm text-gray-500">
-        승인 전까지 강의는 비활성화 상태로 유지됩니다.
-      </p>
+      <p class="text-sm font-bold text-gray-800">삭제 요청은 관리자 승인 후 처리됩니다.</p>
+      <p class="mt-1 text-sm text-gray-500">승인 전까지 강의는 비활성화 상태로 유지됩니다.</p>
     </div>
 
     <div class="flex gap-3">
@@ -408,65 +404,10 @@
   </div>
 </div>
 
-<div id="deleteLiveModal" class="modal-overlay">
-  <div class="bg-white rounded-2xl p-8 max-w-2xl w-full mx-4 shadow-xl">
-    <div class="flex items-center justify-between mb-6">
-      <h3 class="text-2xl font-black text-gray-900">실시간 강의 삭제 요청</h3>
-      <button type="button"
-              onclick="closeDeleteLiveModal()"
-              class="p-2 hover:bg-gray-100 rounded-lg">
-        <i class="fa-solid fa-x"></i>
-      </button>
-    </div>
-
-    <div class="bg-red-50 border-2 border-red-200 rounded-xl p-4 mb-6">
-      <div class="flex items-start gap-3">
-        <i class="fa-solid fa-triangle-exclamation text-red-600 mt-0.5"></i>
-        <div>
-          <p class="text-sm font-bold text-red-900 mb-1">삭제를 요청하시겠습니까?</p>
-          <p class="text-sm text-red-700 font-medium">삭제 시 예약한 수강생에게 알림이 발송됩니다.</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="bg-gray-50 rounded-xl p-6 mb-6 space-y-3">
-      <div class="flex justify-between">
-        <span class="text-sm font-bold text-gray-600">강의명</span>
-        <span id="del-live-title" class="text-sm font-bold text-gray-900"></span>
-      </div>
-    </div>
-
-    <div class="mb-6">
-      <label class="block text-sm font-bold text-gray-900 mb-2">
-        삭제 사유 <span class="text-red-600">*</span>
-      </label>
-      <textarea id="deleteLiveReason"
-                rows="4"
-                placeholder="삭제 요청 사유를 입력해주세요"
-                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none resize-none font-medium"></textarea>
-    </div>
-
-    <div class="flex gap-3">
-      <button type="button"
-              onclick="closeDeleteLiveModal()"
-              class="flex-1 px-6 py-3 border-2 border-gray-300 rounded-xl hover:bg-gray-50 font-bold text-gray-700">
-        취소
-      </button>
-
-      <button type="button"
-              onclick="submitDeleteLive()"
-              class="flex-1 px-6 py-3 bg-red-600 text-white rounded-xl hover:bg-red-700 font-bold">
-        삭제 요청하기
-      </button>
-    </div>
-  </div>
-</div>
-
 <script>
   lucide.createIcons();
 
   let currentDeleteId = null;
-  let currentDeleteLiveId = null;
 
   function getCsrfHeaders() {
     const csrfToken = document.querySelector('meta[name="_csrf"]')?.content;
@@ -502,8 +443,10 @@
       body: formData
     });
 
+    const message = await response.text();
+
     if (!response.ok) {
-      alert('실시간 강의 등록 상태 변경에 실패했습니다.');
+      alert(message || '실시간 강의 등록 상태 변경에 실패했습니다.');
       return;
     }
 
@@ -511,10 +454,33 @@
             ? '실시간 강의 등록 요청이 취소되었습니다.'
             : '실시간 강의 등록 요청이 완료되었습니다.';
 
-    alert(successMessage);
+    alert(message || successMessage);
     location.reload();
   }
 
+  async function deleteLiveLecture(button) {
+    const liveId = button.dataset.id;
+    const title = button.dataset.title || '';
+
+    if (!confirm(`"${title}" 실시간 강의를 삭제하시겠습니까?\n삭제 후에는 되돌릴 수 없습니다.`)) {
+      return;
+    }
+
+    const response = await fetch(`/instructor/live-lecture/${liveId}`, {
+      method: 'DELETE',
+      headers: getCsrfHeaders()
+    });
+
+    const message = await response.text();
+
+    if (!response.ok) {
+      alert(message || '실시간 강의 삭제에 실패했습니다.');
+      return;
+    }
+
+    alert(message || '실시간 강의가 삭제되었습니다.');
+    location.reload();
+  }
 
   async function updateCourseRegistrationStatus(button, nextStatus) {
     const courseId = button.dataset.id;
@@ -537,8 +503,10 @@
       body: formData
     });
 
+    const message = await response.text();
+
     if (!response.ok) {
-      alert('강의 등록 상태 변경에 실패했습니다.');
+      alert(message || '강의 등록 상태 변경에 실패했습니다.');
       return;
     }
 
@@ -546,7 +514,7 @@
             ? '강의 등록 요청이 취소되었습니다.'
             : '강의 등록 요청이 완료되었습니다.';
 
-    alert(successMessage);
+    alert(message || successMessage);
     location.reload();
   }
 
@@ -571,50 +539,6 @@
     form.method = 'POST';
     form.action = `/instructor/course/${currentDeleteId}/delete-request`;
 
-    const csrfToken = document.querySelector('meta[name="_csrf"]')?.content;
-    const csrfParameter = document.querySelector('meta[name="_csrf_parameter"]')?.content;
-
-    if (csrfToken && csrfParameter) {
-      const csrfInput = document.createElement('input');
-      csrfInput.type = 'hidden';
-      csrfInput.name = csrfParameter;
-      csrfInput.value = csrfToken;
-      form.appendChild(csrfInput);
-    }
-
-    document.body.appendChild(form);
-    form.submit();
-  }
-
-  function openDeleteLiveModal(button) {
-    currentDeleteLiveId = button.dataset.id;
-    document.getElementById('del-live-title').textContent = button.dataset.title || '';
-    document.getElementById('deleteLiveReason').value = '';
-    document.getElementById('deleteLiveModal').classList.add('open');
-  }
-
-  function closeDeleteLiveModal() {
-    document.getElementById('deleteLiveModal').classList.remove('open');
-  }
-
-  function submitDeleteLive() {
-    const reason = document.getElementById('deleteLiveReason').value.trim();
-
-    if (!reason) {
-      alert('삭제 사유를 입력해주세요');
-      return;
-    }
-
-    const form = document.createElement('form');
-    form.method = 'POST';
-    form.action = `/instructor/live-lecture/${currentDeleteLiveId}/delete-request`;
-
-    const reasonInput = document.createElement('input');
-    reasonInput.type = 'hidden';
-    reasonInput.name = 'reason';
-    reasonInput.value = reason;
-
-    form.appendChild(reasonInput);
     document.body.appendChild(form);
     form.submit();
   }


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 강사 권한의 실시간 강의 삭제 기능 구현
- 코스 등록/취소/재등록/반려 흐름과 관리자 승인 테이블 연동 처리
- 실시간 강의 삭제 시 관리자 승인 테이블 연관 데이터 정리 로직 추가

## 💡 어떤 기능인가요?
- 강사가 본인이 등록한 실시간 강의를 삭제할 수 있는 기능
- 코스 등록 요청 상태가 관리자 승인 테이블과 일관되게 관리되도록 하는 기능
- 실시간 강의 삭제 시 `admin_approvals.live_id` FK 제약이 발생하지 않도록 관련 승인 요청 데이터를 먼저 정리하는 기능

## ✨ 변경 사항 (Changes)
- `DELETE /instructor/live-lecture/{liveId}` 실시간 강의 삭제 기능 추가
- `LiveLectureService`에 실시간 강의 삭제 비즈니스 로직 추가
- 실시간 강의 삭제 시 강사 본인 또는 관리자 권한 검증 추가
- 실시간 강의 삭제 가능 상태를 승인 대기(PENDING) 및 반려(REJECTED) 상태로 제한
- 실시간 강의 삭제 시 `admin_approvals`의 관련 `LIVE_REGISTER` 승인 요청 데이터 삭제 처리 추가
- 코스 등록 시 `admin_approvals`에 `COURSE_REGISTER` 승인 요청 데이터 생성 로직 추가
- 코스 등록 요청 취소 시 `COURSE_REGISTER / PENDING` 승인 요청 데이터 삭제 로직 추가
- 코스 재등록 요청 시 `COURSE_REGISTER / PENDING` 승인 요청 데이터 재생성 로직 추가
- 코스 등록 요청 반려 시 `Course` 상태를 `REJECTED`로 변경하는 로직 추가
- `AdminApprovalRepository`에 코스 및 실시간 강의 승인 요청 삭제 메서드 추가
- 내 강의 관리 페이지에서 실시간 강의 상태별 삭제/등록 요청 버튼 노출 조건 수정
- **DB 스키마 변경:** 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [x] 버그 수정
- [x] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 승인 대기 상태의 실시간 강의 삭제 확인
- [x] 반려 상태의 실시간 강의 삭제 확인
- [x] 승인 완료, 방송 중, 종료 상태의 실시간 강의 삭제 차단 확인
- [x] 실시간 강의 삭제 시 `admin_approvals.live_id` FK 제약 없이 삭제되는지 확인
- [x] 코스 등록 시 `COURSE_REGISTER / PENDING` 승인 요청 생성 확인
- [x] 코스 등록 요청 취소 시 승인 요청 데이터 삭제 확인
- [x] 코스 재등록 요청 시 승인 요청 데이터 재생성 확인
- [x] 코스 등록 요청 반려 시 `Course.status = REJECTED` 변경 확인
- [x] 반려 또는 요청 취소 상태의 코스 재등록 요청 가능 여부 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 실시간 강의 삭제는 정책상 물리 삭제로 구현함
- 실시간 강의는 `admin_approvals.live_id`가 FK로 연결되어 있어, 삭제 전 관련 승인 요청 데이터를 먼저 삭제하도록 처리함
- 코스 등록 승인 흐름이 관리자 승인 테이블과 연동되지 않던 문제를 보완함
- 코스 등록 요청 취소 시 관리자 승인 목록에 남지 않도록 `COURSE_REGISTER / PENDING` 요청을 삭제함
- 코스 재등록 요청 시 새로운 승인 요청 데이터를 생성하도록 처리함
- 코스 등록 반려 시 도메인 상태도 `REJECTED`로 변경되도록 처리함
- fetch 기반 삭제 요청은 실패 시 에러 페이지 이동이 아닌 현재 페이지에서 메시지를 표시하는 방식으로 처리함

## ✅ 체크 리스트
- [x] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때 해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #162
- Closes #163
