### PR TITLE
[Feature] 내 강의 목록 조회 서버 로직 구현 (GET /my-courses)

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/course/repository/ReviewRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/course/repository/ReviewRepository.java
@@ -1,0 +1,13 @@
+package com.wanted.naeil.domain.course.repository;
+
+import com.wanted.naeil.domain.course.entity.Course;
+import com.wanted.naeil.domain.course.entity.Review;
+import com.wanted.naeil.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Optional<Review> findByUserAndCourse(User user, Course course);
+}

--- a/src/main/java/com/wanted/naeil/domain/learning/controller/MyCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/controller/MyCourseController.java
@@ -1,0 +1,59 @@
+package com.wanted.naeil.domain.learning.controller;
+
+import com.wanted.naeil.domain.learning.dto.response.MyCourseResponse;
+import com.wanted.naeil.domain.learning.service.MyCourseService;
+import com.wanted.naeil.domain.user.entity.User;
+import com.wanted.naeil.domain.user.repository.UserRepository;
+import com.wanted.naeil.global.auth.model.dto.AuthDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Controller
+@RequestMapping("/my-courses")
+@RequiredArgsConstructor
+@Slf4j
+public class MyCourseController {
+
+    private final MyCourseService myCourseService;
+    private final UserRepository userRepository;
+
+    @GetMapping
+    public String myCoursePage(@AuthenticationPrincipal AuthDetails authDetails,
+                               Model model) {
+
+        log.info("[내 강의] 목록 조회 시작");
+
+        User loginUser = getLoginUser(authDetails);
+        List<MyCourseResponse> myCourses = myCourseService.getMyCourses(loginUser);
+
+        double averageRate = myCourses.isEmpty() ? 0 :
+                myCourses.stream()
+                        .mapToDouble(MyCourseResponse::getCoursesRate)
+                        .average()
+                        .orElse(0);
+
+        model.addAttribute("myCourses", myCourses);
+        model.addAttribute("averageRate", (int)averageRate);
+
+        log.info("[내 강의] 목록 조회 완료. 수강 강의 수: {}", myCourses.size());
+
+        return "my-courses/myCourses";
+    }
+
+    // 로그인 유저 조회 공통 메서드
+    private User getLoginUser(AuthDetails authDetails) {
+        if (authDetails == null) {
+            throw new NoSuchElementException("로그인이 필요합니다.");
+        }
+        return userRepository.findByUsername(authDetails.getUsername())
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 유저입니다."));
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/learning/dto/response/MyCourseResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/dto/response/MyCourseResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.naeil.domain.learning.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyCourseResponse {
+
+    // 강의 기본 정보
+    private Long courseId;
+    private String thumbnail;
+    private String title;
+    private String instructorName;
+
+    // 수강 정보
+    private Double coursesRate;
+
+    // 수강평 정보
+    private Long reviewId;
+    private Double rating;
+    private String reviewContent;
+}

--- a/src/main/java/com/wanted/naeil/domain/learning/repository/EnrollmentRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/repository/EnrollmentRepository.java
@@ -16,6 +16,16 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     List<Enrollment> findByUser(User user);
 
+    // 내 강의 페이지용
+    @Query("""
+        SELECT e FROM Enrollment e
+        JOIN FETCH e.course c
+        JOIN FETCH c.instructor
+        WHERE e.user = :user
+        ORDER BY e.createdAt DESC
+    """)
+    List<Enrollment> findByUserWithCourse(@Param("user") User user);
+
     @Query("""
         select e.status
         from Enrollment e

--- a/src/main/java/com/wanted/naeil/domain/learning/service/MyCourseService.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/service/MyCourseService.java
@@ -1,0 +1,47 @@
+package com.wanted.naeil.domain.learning.service;
+
+import com.wanted.naeil.domain.learning.dto.response.MyCourseResponse;
+import com.wanted.naeil.domain.course.entity.Review;
+import com.wanted.naeil.domain.course.repository.ReviewRepository;
+import com.wanted.naeil.domain.learning.entity.Enrollment;
+import com.wanted.naeil.domain.learning.repository.EnrollmentRepository;
+import com.wanted.naeil.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MyCourseService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final ReviewRepository reviewRepository;
+
+    // 내 강의 목록 조회
+    @Transactional(readOnly = true)
+    public List<MyCourseResponse> getMyCourses(User loginUser) {
+
+        List<Enrollment> enrollments = enrollmentRepository.findByUserWithCourse(loginUser);
+        return enrollments.stream()
+                .map(enrollment -> {
+                    Optional<Review> review = reviewRepository.findByUserAndCourse(
+                            loginUser,
+                            enrollment.getCourse()
+                    );
+                    return MyCourseResponse.builder()
+                            .courseId(enrollment.getCourse().getId())
+                            .thumbnail(enrollment.getCourse().getThumbnail())
+                            .title(enrollment.getCourse().getTitle())
+                            .instructorName(enrollment.getCourse().getInstructor().getName())
+                            .coursesRate(enrollment.getCoursesRate())
+                            .reviewId(review.map(Review::getId).orElse(null))
+                            .rating(review.map(Review::getRating).orElse(null))
+                            .reviewContent(review.map(Review::getContent).orElse(null))
+                            .build();
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/wanted/naeil/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/naeil/global/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                     auth.requestMatchers("/dashboard/instructor").hasAnyAuthority("ADMIN", "INSTRUCTOR");
                     auth.requestMatchers("/dashboard/user").hasAnyAuthority("ADMIN", "INSTRUCTOR", "SUBSCRIBER", "USER");
                     auth.requestMatchers("/auth/login", "/auth/signup", "/auth/fail", "/auth/find-id", "/auth/find-password", "/", "/dashboard/guest", "/subscription/**").permitAll();
+                    auth.requestMatchers("/my-courses/**").authenticated();
                     auth.anyRequest().authenticated();
                 })
                 .requestCache(cache -> cache.disable())


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 내 강의 목록 조회 서버 로직 구현 (GET /my-courses)
- Enrollment 기준 수강 강의 목록 조회 및 Review 수강평 정보 포함하여 반환

## 💡 어떤 기능인가요?
- 로그인한 사용자가 /my-courses 진입 시 본인이 수강 중인 강의 목록을 조회하는 서버 로직 구현

## ✨ 변경 사항 (Changes)
- `MyCourseResponse.java` DTO 생성
- `ReviewRepository.java` 생성 — `findByUserAndCourse()` 추가
- `EnrollmentRepository.java` 수정 — `findByUserWithCourse()` fetch join 쿼리 추가 (N+1 방지)
- `MyCourseService.java` 생성 — `getMyCourses()` 구현
- `MyCourseController.java` 생성 — `GET /my-courses` 매핑
- `SecurityConfig.java` 수정 — `/my-courses/**` 인증 설정 추가
- **DB 스키마 변경:** 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 완료 - 임시 테스트용 html 사용

## 📋 테스트 내용 (Testing)
- [x] 로컬 환경에서 DB 데이터 삽입 후 /my-courses 접속하여 수강 강의 목록 정상 출력 확인
- [x] 수강평 없는 경우 null 처리 정상 동작 확인
- [x] 평균 진도율 정상 계산 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- EnrollmentRepository에 기존 findByUser()는 커뮤니티에서 사용 중이라 건드리지 않고, fetch join 적용한 findByUserWithCourse()를 별도로 추가했습니다.
- 수강평 수정/삭제는 팀원 구현 완료 후 PR 2에서 연동 예정입니다.

## ✅ 체크 리스트
- [x] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
- Closes #159 