### PR TITLE
[Feature] 내 강의 페이지 실시간 강의 예약 목록 조회 기능 구현 / 화면 연동

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/learning/controller/MyCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/controller/MyCourseController.java
@@ -2,6 +2,7 @@ package com.wanted.naeil.domain.learning.controller;
 
 import com.wanted.naeil.domain.learning.dto.response.MyCourseResponse;
 import com.wanted.naeil.domain.learning.service.MyCourseService;
+import com.wanted.naeil.domain.live.dto.response.MyLiveReservationResponse;
 import com.wanted.naeil.domain.user.entity.User;
 import com.wanted.naeil.domain.user.repository.UserRepository;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
@@ -25,6 +26,7 @@ public class MyCourseController {
     private final MyCourseService myCourseService;
     private final UserRepository userRepository;
 
+    // 내 강의 목록 조회
     @GetMapping
     public String myCoursePage(@AuthenticationPrincipal AuthDetails authDetails,
                                Model model) {
@@ -33,6 +35,7 @@ public class MyCourseController {
 
         User loginUser = getLoginUser(authDetails);
         List<MyCourseResponse> myCourses = myCourseService.getMyCourses(loginUser);
+        List<MyLiveReservationResponse> liveReservations = myCourseService.getLiveReservations(loginUser);
 
         double averageRate = myCourses.isEmpty() ? 0 :
                 myCourses.stream()
@@ -42,6 +45,7 @@ public class MyCourseController {
 
         model.addAttribute("myCourses", myCourses);
         model.addAttribute("averageRate", (int)averageRate);
+        model.addAttribute("liveReservations", liveReservations);
 
         log.info("[내 강의] 목록 조회 완료. 수강 강의 수: {}", myCourses.size());
 

--- a/src/main/java/com/wanted/naeil/domain/learning/service/MyCourseService.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/service/MyCourseService.java
@@ -5,6 +5,10 @@ import com.wanted.naeil.domain.course.entity.Review;
 import com.wanted.naeil.domain.course.repository.ReviewRepository;
 import com.wanted.naeil.domain.learning.entity.Enrollment;
 import com.wanted.naeil.domain.learning.repository.EnrollmentRepository;
+import com.wanted.naeil.domain.live.dto.response.MyLiveReservationResponse;
+import com.wanted.naeil.domain.live.entity.LiveReservation;
+import com.wanted.naeil.domain.live.entity.enums.LiveReservationStatus;
+import com.wanted.naeil.domain.live.repository.LiveReservationRepository;
 import com.wanted.naeil.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,12 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.stream.Collectors.toList;
+
 @Service
 @RequiredArgsConstructor
 public class MyCourseService {
 
     private final EnrollmentRepository enrollmentRepository;
     private final ReviewRepository reviewRepository;
+    private final LiveReservationRepository liveReservationRepository;
 
     // 내 강의 목록 조회
     @Transactional(readOnly = true)
@@ -42,6 +49,27 @@ public class MyCourseService {
                             .reviewContent(review.map(Review::getContent).orElse(null))
                             .build();
                 })
+                .toList();
+    }
+
+    // 실시간 강의 예약 목록 조회
+    @Transactional(readOnly = true)
+    public List<MyLiveReservationResponse> getLiveReservations(User loginUser) {
+
+        List<LiveReservation> reservations = liveReservationRepository
+                .findByUserAndStatusWithLecture(loginUser, LiveReservationStatus.RESERVED);
+
+        return reservations.stream()
+                .map(r -> MyLiveReservationResponse.builder()
+                        .reservationId(r.getId())
+                        .liveId(r.getLiveLecture().getId())
+                        .title(r.getLiveLecture().getTitle())
+                        .instructorName(r.getLiveLecture().getInstructor().getName())
+                        .startAt(r.getLiveLecture().getStartAt())
+                        .endAt(r.getLiveLecture().getEndAt())
+                        .currentCount(r.getLiveLecture().getCurrentCount())
+                        .maxCapacity(r.getLiveLecture().getMaxCapacity())
+                        .build())
                 .toList();
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/live/dto/response/MyLiveReservationResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/live/dto/response/MyLiveReservationResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.naeil.domain.live.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyLiveReservationResponse {
+
+    // 예약 정보
+    private Long reservationId;
+
+    // 실시간 강의 정보
+    private Long liveId;
+    private String title;
+    private String instructorName;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private Integer currentCount;
+    private Integer maxCapacity;
+}

--- a/src/main/java/com/wanted/naeil/domain/live/repository/LiveReservationRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/live/repository/LiveReservationRepository.java
@@ -1,0 +1,28 @@
+package com.wanted.naeil.domain.live.repository;
+
+import com.wanted.naeil.domain.live.entity.LiveReservation;
+import com.wanted.naeil.domain.live.entity.enums.LiveReservationStatus;
+import com.wanted.naeil.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface LiveReservationRepository extends JpaRepository<LiveReservation, Long> {
+
+
+    // 내 강의 페이지 - RESERVED 상태인 예약 목록 조회 (liveLecture fetch join으로 N+1 방지)
+    @Query("""
+        SELECT r FROM LiveReservation r
+        JOIN FETCH r.liveLecture l
+        JOIN FETCH l.instructor
+        WHERE r.user = :user
+        AND r.status = :status
+        ORDER BY l.startAt ASC
+    """)
+    List<LiveReservation> findByUserAndStatusWithLecture(
+            @Param("user") User user,
+            @Param("status") LiveReservationStatus status
+    );
+}

--- a/src/main/resources/templates/my-courses/myCourses.html
+++ b/src/main/resources/templates/my-courses/myCourses.html
@@ -13,9 +13,9 @@
   </style>
 </head>
 <body class="bg-white">
-<div class="max-w-7xl mx-auto px-6 py-12">
 
-  <!-- 이전으로 -->
+<div th:replace="fragments/userHeader :: userHeader"></div>
+<div class="max-w-7xl mx-auto px-6 py-12">
   <div class="mb-6">
     <a th:href="@{/dashboard}" class="inline-flex items-center gap-2 text-gray-600 hover:text-blue-600 transition-colors">
       <i class="fa-solid fa-chevron-left text-xs"></i>
@@ -23,13 +23,11 @@
     </a>
   </div>
 
-  <!-- Header -->
   <div class="mb-12">
     <h1 class="text-3xl font-bold text-gray-900 mb-2">내 강의</h1>
     <p class="text-gray-600 font-mono">// 수강중인 강의를 관리하세요</p>
   </div>
 
-  <!-- Stats Banner -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
     <div class="bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl p-8 text-white">
       <div class="flex items-center gap-3 mb-4">
@@ -48,7 +46,6 @@
     </div>
   </div>
 
-  <!-- Course List Header -->
   <div class="mb-6">
     <h2 class="text-xl font-semibold text-gray-900 mb-1">
       수강중인 강의 (<span th:text="${#lists.size(myCourses)}">0</span>)
@@ -56,35 +53,25 @@
     <p class="text-sm text-gray-600 font-mono">// 강의를 클릭하여 이어서 학습하세요</p>
   </div>
 
-  <!-- Enrolled Courses Grid -->
   <div th:if="${not #lists.isEmpty(myCourses)}"
        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
     <div th:each="course : ${myCourses}"
          class="bg-white border-2 border-gray-200 rounded-2xl p-6 hover:shadow-xl transition-all">
-
-      <!-- 강의 링크 -->
       <a th:href="@{/course/{id}(id=${course.courseId})}" class="block group">
         <div class="aspect-video bg-gray-100 rounded-xl mb-4 overflow-hidden">
-          <img th:src="${course.thumbnail}" th:alt="${course.title}" src="#" alt="썸네일"
-               class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"/>
+          <img th:src="${course.thumbnail}" th:alt="${course.title}" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"/>
         </div>
-        <h3 class="text-lg font-bold text-gray-900 mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors"
-            th:text="${course.title}">강의 제목</h3>
-        <p class="text-sm text-gray-600 mb-4" th:text="${course.instructorName}">강사명</p>
-
-        <!-- Progress Bar -->
+        <h3 class="text-lg font-bold text-gray-900 mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors" th:text="${course.title}">강의 제목</h3>
+        <p class="text-sm text-gray-600 mb-4 font-bold" th:text="${course.instructorName}">강사명</p>
         <div class="mb-4">
           <div class="flex justify-between items-center mb-2">
             <span class="text-xs font-bold text-gray-600">진행률</span>
             <span class="text-xs font-bold text-blue-600"><span th:text="${course.coursesRate}">0</span>%</span>
           </div>
           <div class="h-2 bg-gray-200 rounded-full overflow-hidden">
-            <div class="h-full bg-gradient-to-r from-blue-600 to-green-600 rounded-full transition-all"
-                 th:style="'width:' + ${course.coursesRate} + '%'"></div>
+            <div class="h-full bg-gradient-to-r from-blue-600 to-green-600 rounded-full transition-all" th:style="'width:' + ${course.coursesRate} + '%'"></div>
           </div>
         </div>
-
-        <!-- 이어보기 버튼 -->
         <div class="mb-4">
           <div class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl font-bold">
             <i class="fa-solid fa-play text-sm"></i>
@@ -92,139 +79,151 @@
           </div>
         </div>
       </a>
-
-      <!-- Review Section -->
       <div class="border-t-2 border-gray-100 pt-4">
-
-        <!-- 수강평 있을 때 -->
         <div th:if="${course.reviewId != null}">
           <div class="flex items-center gap-1 mb-2">
-            <span th:each="i : ${#numbers.sequence(1,5)}"
-                  th:class="${i <= course.rating} ? 'text-yellow-400 text-lg' : 'text-gray-300 text-lg'">★</span>
-            <span class="text-sm font-bold text-gray-700 ml-1" th:text="${course.rating}">4.5</span>
+            <span th:each="i : ${#numbers.sequence(1,5)}" th:class="${i <= course.rating} ? 'text-yellow-400' : 'text-gray-300'">★</span>
+            <span class="text-sm font-bold text-gray-700 ml-1" th:text="${course.rating}">0.0</span>
           </div>
-          <p th:if="${course.reviewContent != null}"
-             class="text-sm text-gray-700 mb-3 leading-relaxed"
-             th:text="${course.reviewContent}">리뷰 내용</p>
+          <p class="text-sm text-gray-700 mb-3 line-clamp-2" th:text="${course.reviewContent}">내용</p>
           <div class="flex gap-2">
-            <!-- 수정 버튼 - 모달 오픈 -->
-            <button type="button"
-                    th:attr="data-review-id=${course.reviewId}, data-rating=${course.rating}, data-content=${course.reviewContent}"
-                    onclick="openUpdateModal(this)"
-                    class="px-3 py-1.5 text-xs border-2 border-blue-300 text-blue-600 rounded-lg hover:bg-blue-50 font-bold">수정</button>
-            <!-- 삭제 버튼 - confirm -->
-            <form th:action="@{/my-courses/reviews/{reviewId}/delete(reviewId=${course.reviewId})}" method="post">
-              <button type="submit"
-                      onclick="return confirm('수강평을 삭제하시겠습니까?')"
-                      class="px-3 py-1.5 text-xs border-2 border-red-300 text-red-600 rounded-lg hover:bg-red-50 font-bold">삭제</button>
+            <button type="button" th:attr="data-review-id=${course.reviewId}, data-rating=${course.rating}, data-content=${course.reviewContent}" onclick="openUpdateModal(this)" class="px-3 py-1.5 text-xs border-2 border-blue-100 text-blue-600 rounded-lg font-bold">수정</button>
+            <form th:action="@{/my-courses/reviews/{id}/delete(id=${course.reviewId})}" method="post">
+              <button type="submit" onclick="return confirm('삭제하시겠습니까?')" class="px-3 py-1.5 text-xs border-2 border-red-100 text-red-600 rounded-lg font-bold">삭제</button>
             </form>
           </div>
         </div>
-
-        <!-- 수강평 없을 때 -->
         <div th:if="${course.reviewId == null}">
-          <button type="button"
-                  th:attr="data-course-id=${course.courseId}"
-                  onclick="openCreateModal(this)"
-                  class="block w-full px-4 py-2 border-2 border-gray-300 text-gray-700 rounded-xl hover:border-blue-600 hover:text-blue-600 transition-all font-bold text-sm text-center">
-            수강평 작성하기
+          <button type="button" th:attr="data-course-id=${course.courseId}" onclick="openCreateModal(this)" class="block w-full px-4 py-2 border-2 border-gray-200 text-gray-600 rounded-xl font-bold text-sm text-center">수강평 작성하기</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div th:if="${#lists.isEmpty(myCourses)}" class="text-center py-16 bg-gray-50 rounded-3xl border-2 border-dashed border-gray-200">
+    <div class="text-4xl mb-4">📖</div>
+    <h3 class="text-lg font-bold text-gray-900 mb-2">수강중인 강의가 없습니다</h3>
+    <a th:href="@{/}" class="inline-block px-6 py-2 bg-blue-600 text-white rounded-lg font-bold">강의 둘러보기</a>
+  </div>
+
+  <div class="mt-20">
+    <div class="mb-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-1 flex items-center gap-2">
+        <i class="fa-solid fa-video text-blue-600"></i>
+        실시간 강의 예약 (<span th:text="${#lists.size(liveReservations)}">0</span>)
+      </h2>
+      <p class="text-sm text-gray-600 font-mono">// 예약한 실시간 강의 목록</p>
+    </div>
+
+    <div th:if="${not #lists.isEmpty(liveReservations)}"
+         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div th:each="reservation : ${liveReservations}"
+           class="bg-white border-2 border-gray-200 rounded-2xl overflow-hidden hover:shadow-xl transition-all hover:border-blue-300 flex flex-col">
+        <div class="relative bg-gray-900 aspect-video flex flex-col justify-center px-6">
+          <div class="flex items-center gap-1.5 px-3 py-1 bg-red-500 text-white rounded-full w-fit mb-3">
+            <span class="w-2 h-2 bg-white rounded-full animate-pulse inline-block"></span>
+            <span class="text-[10px] font-bold tracking-wider">LIVE</span>
+          </div>
+          <h3 class="text-lg font-bold text-white line-clamp-2" th:text="${reservation.title}">강의명</h3>
+        </div>
+        <div class="p-6 flex flex-col flex-grow">
+          <div class="flex items-center gap-2 mb-4">
+            <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center text-blue-600">
+              <i class="fa-solid fa-user-tie text-xs"></i>
+            </div>
+            <span class="text-sm text-gray-600 font-bold" th:text="${reservation.instructorName}">강사명</span>
+          </div>
+          <div class="space-y-2.5 mb-6 text-sm text-gray-500 font-medium">
+            <div class="flex items-center gap-3">
+              <i class="fa-solid fa-calendar text-blue-500/70 w-4"></i>
+              <span class="font-mono" th:text="${#temporals.format(reservation.startAt, 'yyyy-MM-dd')}"></span>
+            </div>
+            <div class="flex items-center gap-3">
+              <i class="fa-solid fa-clock text-blue-500/70 w-4"></i>
+              <span class="font-mono">
+                <span th:text="${#temporals.format(reservation.startAt, 'HH:mm')}"></span> ~
+                <span th:text="${#temporals.format(reservation.endAt, 'HH:mm')}"></span>
+              </span>
+            </div>
+            <div class="flex items-center gap-3">
+              <i class="fa-solid fa-users text-blue-500/70 w-4"></i>
+              <span class="font-mono"><span th:text="${reservation.currentCount}">0</span> / <span th:text="${reservation.maxCapacity}">0</span> 명 참여</span>
+            </div>
+          </div>
+          <button class="mt-auto w-full py-3 border-2 border-red-100 text-red-500 rounded-xl hover:bg-red-50 font-bold text-sm transition-colors">
+            예약 취소
           </button>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- Empty State -->
-  <div th:if="${#lists.isEmpty(myCourses)}" class="text-center py-16">
-    <div class="w-24 h-24 bg-gray-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
-      <span class="text-4xl">📖</span>
+    <div th:if="${#lists.isEmpty(liveReservations)}"
+         class="py-16 bg-gray-50 rounded-3xl border-2 border-gray-100 flex flex-col items-center justify-center text-center">
+      <div class="w-20 h-20 bg-gray-200/50 rounded-2xl flex items-center justify-center mb-6">
+        <i class="fa-solid fa-video text-gray-400 text-3xl"></i>
+      </div>
+      <h3 class="text-xl font-bold text-gray-900 mb-2">예약한 실시간 강의가 없습니다</h3>
+      <p class="text-gray-400 text-sm mb-8 font-medium">실시간 강의를 예약해보세요</p>
+
+      <a th:href="@{/live}" class="inline-flex items-center gap-2 px-8 py-3.5 bg-blue-600 text-white rounded-xl font-bold hover:bg-blue-700 transition-all shadow-lg shadow-blue-100">
+        <i class="fa-solid fa-video text-sm"></i>
+        <span>실시간 강의 보기</span>
+      </a>
     </div>
-    <h3 class="text-lg font-semibold text-gray-900 mb-2">수강중인 강의가 없습니다</h3>
-    <p class="text-gray-500 font-mono text-sm mb-6">새로운 강의를 시작해보세요</p>
-    <a th:href="@{/}" class="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium">
-      강의 둘러보기
-    </a>
   </div>
 
-</div>
-
-<!-- ─── 수강평 작성 모달 ─────────────────────────── -->
-<div id="createModal" class="modal-overlay">
+</div> <div id="createModal" class="modal-overlay">
   <div class="bg-white rounded-2xl p-8 w-full max-w-md mx-4 shadow-2xl">
     <h2 class="text-xl font-bold text-gray-900 mb-6">수강평 작성</h2>
     <form id="createForm" method="post">
-      <!-- 별점 -->
       <div class="mb-4">
         <label class="block text-sm font-bold text-gray-700 mb-2">별점 <span class="text-red-500">*</span></label>
         <div class="flex gap-1" id="createStars">
-          <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="1">★</span>
-          <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="2">★</span>
-          <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="3">★</span>
-          <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="4">★</span>
-          <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="5">★</span>
+          <span th:each="i : ${#numbers.sequence(1,5)}" class="text-3xl cursor-pointer text-gray-300 star-btn" th:attr="data-value=${i}">★</span>
         </div>
         <input type="hidden" id="createRating" name="rating" value="0"/>
       </div>
-      <!-- 내용 -->
       <div class="mb-6">
-        <label class="block text-sm font-bold text-gray-700 mb-2">수강평 내용 <span class="text-gray-400 font-normal">(선택, 100자 이내)</span></label>
-        <textarea name="content" maxlength="100" rows="4"
-                  class="w-full border-2 border-gray-200 rounded-xl p-3 text-sm focus:outline-none focus:border-blue-400 resize-none"
-                  placeholder="강의에 대한 솔직한 후기를 남겨주세요"></textarea>
+        <label class="block text-sm font-bold text-gray-700 mb-2">수강평 내용</label>
+        <textarea name="content" maxlength="100" rows="4" class="w-full border-2 border-gray-200 rounded-xl p-3 text-sm focus:outline-none focus:border-blue-400 resize-none" placeholder="후기를 남겨주세요"></textarea>
       </div>
-      <!-- 버튼 -->
       <div class="flex gap-3">
-        <button type="button" onclick="closeCreateModal()"
-                class="flex-1 py-3 border-2 border-gray-300 text-gray-700 rounded-xl font-bold hover:bg-gray-50">취소</button>
-        <button type="submit"
-                class="flex-1 py-3 bg-blue-600 text-white rounded-xl font-bold hover:bg-blue-700">작성</button>
+        <button type="button" onclick="closeCreateModal()" class="flex-1 py-3 border-2 border-gray-300 text-gray-700 rounded-xl font-bold">취소</button>
+        <button type="submit" class="flex-1 py-3 bg-blue-600 text-white rounded-xl font-bold">작성</button>
       </div>
     </form>
   </div>
 </div>
 
-<!-- ─── 수강평 수정 모달 ─────────────────────────── -->
 <div id="updateModal" class="modal-overlay">
   <div class="bg-white rounded-2xl p-8 w-full max-w-md mx-4 shadow-2xl">
     <h2 class="text-xl font-bold text-gray-900 mb-6">수강평 수정</h2>
     <form id="updateForm" method="post">
-      <!-- 별점 -->
       <div class="mb-4">
         <label class="block text-sm font-bold text-gray-700 mb-2">별점 <span class="text-red-500">*</span></label>
-        <<div class="flex gap-1" id="updateStars">
-        <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="1">★</span>
-        <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="2">★</span>
-        <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="3">★</span>
-        <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="4">★</span>
-        <span class="text-3xl cursor-pointer text-gray-300 star-btn" data-value="5">★</span>
-      </div>
+        <div class="flex gap-1" id="updateStars">
+          <span th:each="i : ${#numbers.sequence(1,5)}" class="text-3xl cursor-pointer text-gray-300 star-btn" th:attr="data-value=${i}">★</span>
+        </div>
         <input type="hidden" id="updateRating" name="rating" value="0"/>
       </div>
-      <!-- 내용 -->
       <div class="mb-6">
-        <label class="block text-sm font-bold text-gray-700 mb-2">수강평 내용 <span class="text-gray-400 font-normal">(선택, 100자 이내)</span></label>
-        <textarea id="updateContent" name="content" maxlength="100" rows="4"
-                  class="w-full border-2 border-gray-200 rounded-xl p-3 text-sm focus:outline-none focus:border-blue-400 resize-none"
-                  placeholder="강의에 대한 솔직한 후기를 남겨주세요"></textarea>
+        <label class="block text-sm font-bold text-gray-700 mb-2">수강평 내용</label>
+        <textarea id="updateContent" name="content" maxlength="100" rows="4" class="w-full border-2 border-gray-200 rounded-xl p-3 text-sm focus:outline-none focus:border-blue-400 resize-none"></textarea>
       </div>
-      <!-- 버튼 -->
       <div class="flex gap-3">
-        <button type="button" onclick="closeUpdateModal()"
-                class="flex-1 py-3 border-2 border-gray-300 text-gray-700 rounded-xl font-bold hover:bg-gray-50">취소</button>
-        <button type="submit"
-                class="flex-1 py-3 bg-blue-600 text-white rounded-xl font-bold hover:bg-blue-700">수정</button>
+        <button type="button" onclick="closeUpdateModal()" class="flex-1 py-3 border-2 border-gray-300 text-gray-700 rounded-xl font-bold">취소</button>
+        <button type="submit" class="flex-1 py-3 bg-blue-600 text-white rounded-xl font-bold">수정</button>
       </div>
     </form>
   </div>
 </div>
 
 <script>
-  // ─── 0.5점 단위 별점 공통 함수 ───────────────────
+  // 별점 및 모달 스크립트
   function initStars(containerId, hiddenInputId) {
     const container = document.getElementById(containerId);
     const input = document.getElementById(hiddenInputId);
     const stars = container.querySelectorAll('.star-btn');
-
     stars.forEach(star => {
       star.addEventListener('mousemove', function(e) {
         const rect = this.getBoundingClientRect();
@@ -232,7 +231,6 @@
         const value = isHalf ? parseFloat(this.dataset.value) - 0.5 : parseFloat(this.dataset.value);
         renderStars(stars, value);
       });
-
       star.addEventListener('click', function(e) {
         const rect = this.getBoundingClientRect();
         const isHalf = e.clientX < rect.left + rect.width / 2;
@@ -240,10 +238,7 @@
         input.value = value;
         renderStars(stars, value);
       });
-
-      star.addEventListener('mouseleave', function() {
-        renderStars(stars, parseFloat(input.value));
-      });
+      star.addEventListener('mouseleave', function() { renderStars(stars, parseFloat(input.value)); });
     });
   }
 
@@ -251,25 +246,19 @@
     stars.forEach(star => {
       const starVal = parseFloat(star.dataset.value);
       if (value >= starVal) {
-        star.style.background = 'none';
-        star.style.webkitTextFillColor = '';
-        star.classList.add('text-yellow-400');
-        star.classList.remove('text-gray-300');
+        star.classList.add('text-yellow-400'); star.classList.remove('text-gray-300');
+        star.style.background = 'none'; star.style.webkitTextFillColor = '';
       } else if (value >= starVal - 0.5) {
         star.classList.remove('text-yellow-400', 'text-gray-300');
         star.style.background = 'linear-gradient(to right, #facc15 50%, #d1d5db 50%)';
-        star.style.webkitBackgroundClip = 'text';
-        star.style.webkitTextFillColor = 'transparent';
+        star.style.webkitBackgroundClip = 'text'; star.style.webkitTextFillColor = 'transparent';
       } else {
-        star.style.background = 'none';
-        star.style.webkitTextFillColor = '';
-        star.classList.remove('text-yellow-400');
-        star.classList.add('text-gray-300');
+        star.classList.remove('text-yellow-400'); star.classList.add('text-gray-300');
+        star.style.background = 'none'; star.style.webkitTextFillColor = '';
       }
     });
   }
 
-  // ─── 수강평 작성 모달 ───────────────────────────
   function openCreateModal(btn) {
     const courseId = btn.getAttribute('data-course-id');
     document.getElementById('createForm').action = '/my-courses/' + courseId + '/reviews';
@@ -278,17 +267,12 @@
     document.getElementById('createModal').classList.add('open');
     initStars('createStars', 'createRating');
   }
+  function closeCreateModal() { document.getElementById('createModal').classList.remove('open'); }
 
-  function closeCreateModal() {
-    document.getElementById('createModal').classList.remove('open');
-  }
-
-  // ─── 수강평 수정 모달 ───────────────────────────
   function openUpdateModal(btn) {
     const reviewId = btn.getAttribute('data-review-id');
     const rating = parseFloat(btn.getAttribute('data-rating'));
     const content = btn.getAttribute('data-content');
-
     document.getElementById('updateForm').action = '/my-courses/reviews/' + reviewId + '/update';
     document.getElementById('updateRating').value = rating;
     document.getElementById('updateContent').value = content || '';
@@ -296,19 +280,11 @@
     document.getElementById('updateModal').classList.add('open');
     initStars('updateStars', 'updateRating');
   }
+  function closeUpdateModal() { document.getElementById('updateModal').classList.remove('open'); }
 
-  function closeUpdateModal() {
-    document.getElementById('updateModal').classList.remove('open');
-  }
-
-  // ─── 모달 외부 클릭 시 닫기 ─────────────────────
-  document.getElementById('createModal').addEventListener('click', function(e) {
-    if (e.target === this) closeCreateModal();
-  });
-  document.getElementById('updateModal').addEventListener('click', function(e) {
-    if (e.target === this) closeUpdateModal();
+  document.querySelectorAll('.modal-overlay').forEach(modal => {
+    modal.addEventListener('click', function(e) { if (e.target === this) this.classList.remove('open'); });
   });
 </script>
-
 </body>
 </html>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 내 강의 페이지 실시간 강의 예약 목록 조회 기능 구현 및 화면 연동
- userHeader fragment 연결 및 UI 개선

## 💡 어떤 기능인가요?
- 로그인한 사용자가 /my-courses 진입 시 예약한 실시간 강의 목록을 함께 조회하는 기능 구현

## ✨ 변경 사항 (Changes)
- `MyLiveReservationResponse.java` DTO 생성
- `LiveReservationRepository.java` 생성 — `findByUserAndStatusWithLecture()` fetch join 쿼리 추가 (N+1 방지)
- `MyCourseService.java` 수정 — `getLiveReservations()` 추가
- `MyCourseController.java` 수정 — Model에 `liveReservations` 추가
- `myCourses.html` 수정 — 실시간 강의 예약 목록 섹션 추가, userHeader fragment 연결
- **DB 스키마 변경:** 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 더미데이터 기반 실시간 강의 예약 목록 정상 출력 확인
- [x] 예약 목록 없을 때 empty state 정상 출력 확인
- [x] 날짜/시간/인원 정상 출력 확인
- [x] userHeader fragment 정상 연결 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- LiveReservationRepository는 구현 전 임시로 직접 생성했습니다. 추후 조율 필요합니다.
- 예약 취소 버튼은 LiveReservation 관련 기능 구현 완료 후 URL 연동 예정입니다.
- RESERVED 상태인 예약만 조회하며 fetch join으로 N+1 문제를 방지했습니다.

## ✅ 체크 리스트
- [x] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
- Closes #161 