### PR TITLE
실시간 강의 예약 기능 구현

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/live/controller/UserLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/UserLiveController.java
@@ -5,11 +5,15 @@ import com.wanted.naeil.domain.live.service.LiveLectureService;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
 
@@ -21,22 +25,53 @@ public class UserLiveController {
 
     private final LiveLectureService liveLectureService;
 
+    // 실시간 강의 전체 조회
     @GetMapping
     public ModelAndView liveLectureListPage(
             @AuthenticationPrincipal AuthDetails authDetails,
             ModelAndView mv
             ) {
-        List<LiveLectureListResponse> sessions = liveLectureService.getLiveLectureList();
-
-        log.info("[LiveLectureList] 사용자 실시간 강의 전체 조회 성공");
+        Long userId = null;
 
         if (authDetails != null) {
+            userId = authDetails.getLoginUserDTO().getUserId();
             mv.addObject("user", authDetails.getLoginUserDTO());
         }
+
+        List<LiveLectureListResponse> sessions = liveLectureService.getLiveLectureList(userId);
+
+        log.info("[LiveLectureList] 사용자 실시간 강의 전체 조회 성공");
 
         mv.addObject("sessions", sessions);
         mv.setViewName("live/liveLectureList");
 
         return mv;
+    }
+
+    // 실시가 강의 에약
+    @PostMapping("/{liveId}/reservations")
+    public String reserveLiveLecture(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long liveId,
+            RedirectAttributes  redirectAttributes
+    ) {
+
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인 후 실시간 강의를 예약할 수 있습니다.");
+        }
+
+        Long userId = authDetails.getLoginUserDTO().getUserId();
+
+        try {
+            liveLectureService.reserveLiveLecture(userId, liveId);
+            redirectAttributes.addFlashAttribute("message", "실시간 강의 예약이 완료되었습니다");
+            // TODO : 현지랑 합병 후, 내 강의 페이지로 이동시켜주기
+//            return "redirect:/my-courses";
+            return "redirect:/live-lecture/reservations/complete";
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/live-lecture";
+        }
+
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/live/dto/response/LiveLectureListResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/live/dto/response/LiveLectureListResponse.java
@@ -26,22 +26,17 @@ public class LiveLectureListResponse {
     private boolean isLive; // live 중인지
     private boolean isFull; // 꽉 찾는지 TODO : 추후에, 만약 꽉차지 않으면 바로 상세 조회 가능하게
     private boolean reservable; // 예약 가능 여부
+    private boolean isMyReserved; // 내 예약 여부
 
-    public static LiveLectureListResponse of(LiveLecture liveLecture) {
-
-        LocalDateTime now = LocalDateTime.now();
-
-        int maxCapacity = liveLecture.getMaxCapacity();
-        int currentCount = liveLecture.getCurrentCount();
-        int reservationRate = calculateReservationRate(currentCount, maxCapacity);
-        boolean isLive = isLiveNow(liveLecture.getStartAt(), liveLecture.getEndAt(), now);
-        boolean isClosingSoon = reservationRate >= 80;
-        boolean isFull = currentCount >= maxCapacity;
-        boolean isEnded = liveLecture.getEndAt() != null && !now.isBefore(liveLecture.getEndAt());
-        boolean reservable = liveLecture.getStatus() == LiveLectureStatus.APPROVED
-                && !isEnded
-                && !isFull;
-
+    public static LiveLectureListResponse of(
+            LiveLecture liveLecture,
+            int reservationRate,
+            boolean isClosingSoon,
+            boolean isLive,
+            boolean isFull,
+            boolean reservable,
+            boolean isMyReserved
+    ) {
         return LiveLectureListResponse.builder()
                 .liveId(liveLecture.getId())
                 .instructorName(liveLecture.getInstructor().getName())
@@ -51,31 +46,14 @@ public class LiveLectureListResponse {
                 .reservationStartAt(liveLecture.getReservationStartAt())
                 .startAt(liveLecture.getStartAt())
                 .endAt(liveLecture.getEndAt())
-                .currentCount(currentCount)
-                .maxCapacity(maxCapacity)
+                .currentCount(liveLecture.getCurrentCount())
+                .maxCapacity(liveLecture.getMaxCapacity())
                 .reservationRate(reservationRate)
                 .isClosingSoon(isClosingSoon)
                 .isLive(isLive)
                 .isFull(isFull)
                 .reservable(reservable)
+                .isMyReserved(isMyReserved)
                 .build();
-    }
-
-    // 라이브 여부
-    private static boolean isLiveNow(LocalDateTime startAt, LocalDateTime endAt, LocalDateTime now) {
-        if (startAt == null || endAt == null) {
-            return false;
-        }
-
-        return !now.isBefore(startAt) && now.isBefore(endAt);
-    }
-
-    // 예약율 계산
-    private static int calculateReservationRate(int currentCount, int maxCapacity) {
-        if (maxCapacity <= 0) {
-            return 0;
-        }
-
-        return currentCount * 100 / maxCapacity;
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/live/repository/LiveLectureRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/live/repository/LiveLectureRepository.java
@@ -2,11 +2,16 @@ package com.wanted.naeil.domain.live.repository;
 
 import com.wanted.naeil.domain.live.entity.LiveLecture;
 import com.wanted.naeil.domain.live.entity.enums.LiveLectureStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface LiveLectureRepository extends JpaRepository<LiveLecture, Long> {
 
@@ -24,6 +29,11 @@ public interface LiveLectureRepository extends JpaRepository<LiveLecture, Long> 
             List<LiveLectureStatus> statuses,
             LocalDateTime now
     );
+
+    // 비관적 락 추가
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select l from LiveLecture l where l.id = :liveId")
+    Optional<LiveLecture> findByIdForUpdate(@Param("liveId") Long liveId);
 
 
 }

--- a/src/main/java/com/wanted/naeil/domain/live/repository/LiveReservationRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/live/repository/LiveReservationRepository.java
@@ -1,0 +1,33 @@
+package com.wanted.naeil.domain.live.repository;
+
+import com.wanted.naeil.domain.live.entity.LiveLecture;
+import com.wanted.naeil.domain.live.entity.LiveReservation;
+import com.wanted.naeil.domain.live.entity.enums.LiveReservationStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LiveReservationRepository extends JpaRepository<LiveReservation, Long> {
+
+    boolean existsByUser_IdAndLiveLecture_IdAndStatus(
+            Long userId,
+            Long liveId,
+            LiveReservationStatus status
+    );
+
+    @Query("""
+        select r.liveLecture.id
+        from LiveReservation r
+        where r.user.id = :userId
+          and r.status = :status
+        """)
+    List<Long> findLiveIdsByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") LiveReservationStatus status
+    );
+}

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -7,8 +7,11 @@ import com.wanted.naeil.domain.live.dto.response.InstructorLiveDetailResponse;
 import com.wanted.naeil.domain.live.dto.response.InstructorLiveLectureResponse;
 import com.wanted.naeil.domain.live.dto.response.LiveLectureListResponse;
 import com.wanted.naeil.domain.live.entity.LiveLecture;
+import com.wanted.naeil.domain.live.entity.LiveReservation;
 import com.wanted.naeil.domain.live.entity.enums.LiveLectureStatus;
+import com.wanted.naeil.domain.live.entity.enums.LiveReservationStatus;
 import com.wanted.naeil.domain.live.repository.LiveLectureRepository;
+import com.wanted.naeil.domain.live.repository.LiveReservationRepository;
 import com.wanted.naeil.domain.user.entity.User;
 import com.wanted.naeil.domain.user.entity.enums.Role;
 import com.wanted.naeil.domain.user.repository.UserRepository;
@@ -20,7 +23,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -28,8 +34,10 @@ import java.util.List;
 public class LiveLectureService {
 
     private final LiveLectureRepository liveLectureRepository;
+    private final LiveReservationRepository liveReservationRepository;
     private final UserRepository userRepository;
     private final AdminApprovalRepository adminApprovalRepository;
+
 
     // 실시간 강의 등록
     @Transactional
@@ -178,26 +186,122 @@ public class LiveLectureService {
 
     // 실시간 강의 전체 조회 - 유저
     @Transactional(readOnly = true)
-    public List<LiveLectureListResponse> getLiveLectureList() {
+    public List<LiveLectureListResponse> getLiveLectureList(Long userId) {
 
         log.info("[LiveLectureList] 사용자 실시간 강의 전체 조회 시작");
 
+        // 승인완료, 방송 중 강의만 담기
         List<LiveLectureStatus> visibleStatuses = List.of(
                 LiveLectureStatus.APPROVED,
                 LiveLectureStatus.IN_PROGRESS
         );
 
-        return liveLectureRepository.findByStatusInAndEndAtAfterOrderByStartAtAsc(
-                        visibleStatuses,
-                        LocalDateTime.now()
-                ).stream()
-                .map(LiveLectureListResponse::of)
-                .toList();
+        // 종료 전인 실시간 강의 조회
+        List<LiveLecture> liveLectures = liveLectureRepository.findByStatusInAndEndAtAfterOrderByStartAtAsc(
+                visibleStatuses,
+                LocalDateTime.now()
+        );
 
+        // 내가 예약한 강의 조회 및 add
+        Set<Long> reservedLiveIds = new HashSet<>();
+
+        if (userId != null) {
+            List<Long> reservedIds = liveReservationRepository
+                    .findLiveIdsByUserIdAndStatus(userId, LiveReservationStatus.RESERVED);
+            reservedLiveIds.addAll(reservedIds);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        return liveLectures.stream()
+                .map(liveLecture -> toLiveLectureListResponse(
+                        liveLecture,
+                        reservedLiveIds.contains(liveLecture.getId()), // 내가 예약한 강의인가 확인
+                        now
+                ))
+                .toList();
+    }
+
+    // 실시간 강의 예약 기능 - 유저
+    @Transactional
+    public void reserveLiveLecture(Long userId, Long liveId) {
+
+        log.info("[LiveLectureReserve] 실시간 강의 예약 시작 - userId: {}, liveId: {}", userId, liveId);
+
+        LiveLecture liveLecture = liveLectureRepository.findByIdForUpdate(liveId)
+                .orElseThrow(() -> new IllegalArgumentException("실시간 강의를 찾을 수 없습니다. ID: " + liveId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다. ID: " + userId));
+
+        if (user.getRole() != Role.USER) {
+            throw new AccessDeniedException("강의를 예약하려면 로그인을 해주세요.");
+        }
+
+        boolean alreadyReserved = liveReservationRepository.existsByUser_IdAndLiveLecture_IdAndStatus(
+                userId,
+                liveId,
+                LiveReservationStatus.RESERVED
+        );
+
+        if (alreadyReserved) {
+            throw new IllegalStateException("이미 예약하신 강의입니다.");
+        }
+
+        // 예약 시간 검증
+        validateLiveLectureReservable(liveLecture);
+
+        LiveReservation reservation = LiveReservation.builder()
+                .user(user)
+                .liveLecture(liveLecture)
+                .build();
+
+        liveReservationRepository.save(reservation);
+
+        liveLecture.incrementReservation();
+
+        log.info("[LiveLectureReserve] 실시간 강의 예약 완료 - userId: {}, liveId: {}", userId, liveId);
     }
 
 
     // ====== 내부 편의 메서드 =======
+
+    // 강의 예약 변환 메서드
+    private LiveLectureListResponse toLiveLectureListResponse(
+            LiveLecture liveLecture,
+            boolean isMyReserved,
+            LocalDateTime now
+    ) {
+        int currentCount = liveLecture.getCurrentCount();
+        int maxCapacity = liveLecture.getMaxCapacity();
+
+        int reservationRate = calculateReservationRate(currentCount, maxCapacity);
+        boolean isClosingSoon = reservationRate >= 80;
+        boolean isLive = isLiveNow(liveLecture.getStartAt(), liveLecture.getEndAt(), now);
+        boolean isFull = currentCount >= maxCapacity;
+        boolean isEnded = liveLecture.getEndAt() != null && !now.isBefore(liveLecture.getEndAt());
+
+        boolean reservableStatus = liveLecture.getStatus() == LiveLectureStatus.APPROVED
+                || liveLecture.getStatus() == LiveLectureStatus.IN_PROGRESS;
+
+        boolean reservable = reservableStatus
+                && !isEnded
+                && !isFull
+                && !isMyReserved;
+
+        return LiveLectureListResponse.of(
+                liveLecture,
+                reservationRate,
+                isClosingSoon,
+                isLive,
+                isFull,
+                reservable,
+                isMyReserved
+        );
+    }
+
+
+    // 실시간 강의 등록 시간값 검증
     private void validateLiveLectureTime(CreateLiveLectureRequest request) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime startAt = request.getStartAt();
@@ -233,6 +337,7 @@ public class LiveLectureService {
         }
     }
 
+    // 실시간 강의 필수 값 검증
     private void validateLiveLectureRequiredValues(CreateLiveLectureRequest request) {
         if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
             throw new IllegalArgumentException("실시간 강의 제목은 필수 입력 값입니다.");
@@ -255,6 +360,7 @@ public class LiveLectureService {
         }
     }
 
+    // 본인 강의 검증
     private void validateLiveLectureOwnerOrAdmin(User user, LiveLecture liveLecture) {
         if (user.getRole() == Role.ADMIN) {
             return;
@@ -267,5 +373,42 @@ public class LiveLectureService {
         if (!liveLecture.getInstructor().getId().equals(user.getId())) {
             throw new AccessDeniedException("본인이 등록한 실시간 강의만 조회할 수 있습니다.");
         }
+    }
+
+    // 실시간 강의 예약 검증
+    private void validateLiveLectureReservable(LiveLecture liveLecture) {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        LiveLectureStatus status = liveLecture.getStatus();
+
+        if (status != LiveLectureStatus.APPROVED && status != LiveLectureStatus.IN_PROGRESS) {
+            throw new IllegalStateException("예약 가능한 실시간 강의가 아닙니다.");
+        }
+
+        if (liveLecture.getEndAt() == null || !now.isBefore(liveLecture.getEndAt())) {
+            throw new IllegalStateException("이미 종료된 실시간 강의는 예약할 수 없습니다.");
+        }
+
+        if (liveLecture.getCurrentCount() >= liveLecture.getMaxCapacity()) {
+            throw new IllegalStateException("정원이 초과되어 예약이 마감되었습니다.");
+        }
+    }
+
+    // 예약률 계산
+    private int calculateReservationRate(int currentCount, int maxCapacity) {
+        if (maxCapacity <= 0) {
+            return 0;
+        }
+        return currentCount * 100 / maxCapacity;
+    }
+
+    // 실시간 강의 여부 검증
+    private boolean isLiveNow(LocalDateTime startAt, LocalDateTime endAt, LocalDateTime now) {
+        if (startAt == null || endAt == null) {
+            return false;
+        }
+
+        return !now.isBefore(startAt) && now.isBefore(endAt);
     }
 }

--- a/src/main/resources/templates/live/liveLectureList.html
+++ b/src/main/resources/templates/live/liveLectureList.html
@@ -173,32 +173,46 @@
                 </div>
 
                 <div class="space-y-3">
-                    <a th:if="${liveLecture.live}"
+                    <!-- 내가 예약했고, 강의가 시작되었으면 입장하기 -->
+                    <a th:if="${liveLecture.myReserved and liveLecture.live}"
                        th:href="@{/dashboard/live-room/{id}(id=${liveLecture.liveId})}"
                        href="/dashboard/live-room/1"
                        class="flex w-full items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-blue-600 to-green-600 py-4 text-center font-black text-white transition-all hover:shadow-lg">
                         <i class="fa-solid fa-video text-sm"></i>
-                        참여하기
+                        입장하기
                     </a>
 
-                    <button th:if="${liveLecture.reservable}"
+                    <!-- 내가 예약했고, 아직 강의 시작 전이면 취소하기 -->
+                    <button th:if="${liveLecture.myReserved and !liveLecture.live}"
                             type="button"
                             th:data-id="${liveLecture.liveId}"
                             th:data-title="${liveLecture.title}"
-                            th:data-reserved="false"
+                            onclick="handleCancelReservation(this)"
+                            class="w-full rounded-lg border-2 border-red-300 bg-white py-4 font-black text-red-600 transition-all hover:bg-red-50">
+                        취소하기
+                    </button>
+
+                    <!-- 내가 예약하지 않았고, 예약 가능하면 예약하기 -->
+                    <button th:if="${!liveLecture.myReserved and liveLecture.reservable}"
+                            type="button"
+                            th:data-id="${liveLecture.liveId}"
+                            th:data-title="${liveLecture.title}"
+                            th:data-reserved="${liveLecture.myReserved}"
                             onclick="handleReservation(this)"
                             class="w-full rounded-lg bg-blue-600 py-4 font-black text-white transition-all hover:bg-blue-700 hover:shadow-lg">
                         예약하기
                     </button>
 
-                    <button th:if="${!liveLecture.reservable and liveLecture.full}"
+                    <!-- 내가 예약하지 않았고, 정원이 가득 찼으면 마감됨 -->
+                    <button th:if="${!liveLecture.myReserved and !liveLecture.reservable and liveLecture.full}"
                             type="button"
                             disabled
                             class="w-full cursor-not-allowed rounded-lg bg-gray-100 py-4 font-black text-gray-400">
                         마감됨
                     </button>
 
-                    <button th:if="${!liveLecture.live and !liveLecture.reservable and !liveLecture.full}"
+                    <!-- 그 외 예약 불가 -->
+                    <button th:if="${!liveLecture.myReserved and !liveLecture.live and !liveLecture.reservable and !liveLecture.full}"
                             type="button"
                             disabled
                             class="w-full cursor-not-allowed rounded-lg bg-gray-100 py-4 font-black text-gray-400">
@@ -232,7 +246,7 @@
 
 <div id="confirmModal" class="modal-overlay">
     <div class="bg-white rounded-2xl p-8 max-w-md w-full mx-4 shadow-xl">
-        <h3 class="text-xl font-black text-gray-900 mb-4">강의 예약</h3>
+        <h3 class="text-xl font-black text-gray-900 mb-4">실시간 강의 예약</h3>
         <p id="confirmMessage" class="text-gray-600 mb-6 font-medium">해당 강의를 예약하시겠습니까?</p>
 
         <form id="reservationForm" method="post">
@@ -255,6 +269,7 @@
 <div id="alertModal" class="modal-overlay">
     <div class="bg-white rounded-2xl p-8 max-w-md w-full mx-4 shadow-xl text-center">
         <p id="alertMessage" class="text-gray-800 font-bold mb-6">이미 예약한 강의입니다</p>
+
         <button type="button"
                 onclick="document.getElementById('alertModal').classList.remove('open')"
                 class="px-6 py-3 bg-blue-600 text-white rounded-xl font-bold hover:bg-blue-700 transition-all">
@@ -265,7 +280,7 @@
 
 <script>
     function handleReservation(btn) {
-        const sessionId = btn.dataset.id;
+        const liveId = btn.dataset.id;
         const title = btn.dataset.title;
         const isReserved = btn.dataset.reserved === 'true';
 
@@ -276,12 +291,17 @@
         }
 
         document.getElementById('confirmMessage').textContent = `"${title}" 강의를 예약하시겠습니까?`;
-        document.getElementById('reservationForm').action = `/dashboard/live-booking/${sessionId}/reserve`;
+        document.getElementById('reservationForm').action = `/live-lecture/${liveId}/reservations`;
         document.getElementById('confirmModal').classList.add('open');
     }
 
     function closeModal() {
         document.getElementById('confirmModal').classList.remove('open');
+    }
+
+    function handleCancelReservation(btn) {
+        const title = btn.dataset.title;
+        alert(`"${title}" 예약 취소 기능은 아직 준비 중입니다.`);
     }
 </script>
 </body>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 사용자 실시간 강의 예약 기능 구현
- 비관적 락을 사용하여 동시 예약 요청 시 정원 초과를 방지하도록 처리
- 실시간 강의 목록에서 내 예약 여부에 따라 버튼 상태가 변경되도록 개선

## 💡 어떤 기능인가요?
- 사용자가 실시간 강의를 예약할 수 있는 기능입니다.
- 승인 완료 또는 방송 중 상태의 실시간 강의를 강의 종료 전까지 예약할 수 있습니다.
- 이미 예약한 강의는 중복 예약을 차단하고, 목록 화면에서 예약 상태에 따라 버튼을 다르게 표시합니다.

## ✨ 변경 사항 (Changes)
- POST /live-lecture/{liveId}/reservations 
- LiveReservationRepository 추가
- LiveLectureRepository 에 비관적 락 조회 메서드 추가
- LiveLectureService 에 실시간 강의 예약 로직 추가
- 실시간 강의 예약 시 중복 예약 검증 추가
- 실시간 강의 예약 시 정원 초과 검증 추가
- 실시간 강의 예약 시 예약 가능 상태 및 종료 시간 검증 추가
- 예약 성공 시 LiveReservation 저장 및 LiveLecture.currentCount 증가 처리
- 실시간 강의 목록 조회 시 로그인 사용자의 예약 여부 조회 로직 추가
- LiveLectureListResponse에 내 예약 여부 필드 추가
- 실시간 강의 목록 화면에서 예약 상태에 따라 버튼 분기 처리
- 예약 성공 후 임시 완료 페이지로 이동 처리

## 📝 작업 상세 내용
- [x] 기능 구현
- [x] 버그 수정
- [x] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 실시간 강의 목록에서 예약하기 버튼 클릭 시 예약 확인 모달 출력 확인
- [x] 예약 확인 후 POST /live-lecture/{liveId}/reservations 요청 처리 확인
- [x] 예약 성공 시 live_reservations 테이블 INSERT 확인
- [x] 예약 성공 시 live_lectures.current_count 증가 확인
- [x] 이미 예약한 강의 중복 예약 차단 확인
- [x] 정원이 가득 찬 강의 예약 차단 확인
- [x] 강의 종료 시간이 지난 강의 예약 불가 확인
- [x] 예약한 강의가 목록에서 취소하기 또는 입장하기 버튼으로 표시되는지 확인
- [x] 예약하지 않은 강의는 예약하기 버튼으로 표시되는지 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)

## 💬 리뷰어에게 할 말
- 동시 예약 요청으로 인한 정원 초과를 방지하기 위해 비관적 락을 사용했습니다.
- 실시간 강의 목록 조회 시 사용자가 예약한 liveId목록을 한 번에 조회한 뒤 Set으로 변환하여 예약 여부를 판단했습니다.
- DTO에는 계산 결과만 담고, 예약 가능 여부와 내 예약 여부 판단은 Service 계층에서 처리했습니다.
- 예약 취소 기능은 별도 기능으로 분리하여 이후 구현 예정입니다.
- 현재 예약 성공 후 이동 페이지는 내 강의 페이지 병합 전까지 임시 완료 페이지로 연결했습니다.

## ✅ 체크 리스트
- [x] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때 해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #185 
