### PR TITLE
실시간 강의 삭제, 강사-실시간 강의 신청자 조회 기능 구현

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/learning/controller/MyCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/controller/MyCourseController.java
@@ -34,6 +34,7 @@ public class MyCourseController {
         log.info("[내 강의] 목록 조회 시작");
 
         User loginUser = getLoginUser(authDetails);
+        model.addAttribute("user", authDetails.getLoginUserDTO());
         List<MyCourseResponse> myCourses = myCourseService.getMyCourses(loginUser);
         List<MyLiveReservationResponse> liveReservations = myCourseService.getLiveReservations(loginUser);
 

--- a/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
@@ -2,6 +2,7 @@ package com.wanted.naeil.domain.live.controller;
 
 import com.wanted.naeil.domain.live.dto.request.CreateLiveLectureRequest;
 import com.wanted.naeil.domain.live.dto.response.InstructorLiveDetailResponse;
+import com.wanted.naeil.domain.live.dto.response.InstructorLiveReservationResponse;
 import com.wanted.naeil.domain.live.service.LiveLectureService;
 import com.wanted.naeil.domain.user.entity.enums.Role;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
@@ -229,5 +230,27 @@ public class InstLiveController {
             log.warn("[LiveLectureDelete] 삭제 불가 상태 - liveId: {}, message: {}", liveId, e.getMessage());
             return ResponseEntity.status(409).body(e.getMessage());
         }
+    }
+
+    // 실시간 강의 신청자 조회
+    @GetMapping("/live-lecture/{liveId}/reservations")
+    @ResponseBody
+    public ResponseEntity<List<InstructorLiveReservationResponse>> getLiveLectureReservations(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long liveId
+    ) {
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인 후 예약자 목록을 조회할 수 있습니다.");
+        }
+
+        Long instructorId = authDetails.getLoginUserDTO().getUserId();
+
+        log.info("[LiveReservationList] 실시간 강의 예약자 목록 조회 요청 - instructorId: {}, liveId: {}",
+                instructorId, liveId);
+
+        List<InstructorLiveReservationResponse> reservations =
+                liveLectureService.getInstructorLiveReservations(instructorId, liveId);
+
+        return ResponseEntity.ok(reservations);
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/live/controller/UserLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/UserLiveController.java
@@ -8,10 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
@@ -66,12 +63,40 @@ public class UserLiveController {
             liveLectureService.reserveLiveLecture(userId, liveId);
             redirectAttributes.addFlashAttribute("message", "실시간 강의 예약이 완료되었습니다");
             // TODO : 현지랑 합병 후, 내 강의 페이지로 이동시켜주기
-//            return "redirect:/my-courses";
-            return "redirect:/live-lecture/reservations/complete";
+            return "redirect:/my-courses";
         } catch (IllegalStateException | IllegalArgumentException e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
             return "redirect:/live-lecture";
         }
+
+    }
+
+    // 실시간 강의 취소 기능
+    @PostMapping("/{liveId}/reservations/cancel")
+    public String cancelLiveLectureReservation(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long liveId,
+            @RequestParam(required = false) String redirect,
+            RedirectAttributes redirectAttributes
+    ) {
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인 후 실시간 강의 예약을 취소할 수 있습니다.");
+        }
+
+        Long userId = authDetails.getLoginUserDTO().getUserId();
+
+        try {
+            liveLectureService.cancelLiveLectureReservation(userId, liveId);
+            redirectAttributes.addFlashAttribute("message", "실시간 강의 예약이 취소되었습니다.");
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+
+        String redirectPath = "my-courses".equals(redirect)
+                ? "/my-courses"
+                : "/live-lecture";
+
+        return "redirect:" + redirectPath;
 
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/live/controller/UserLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/UserLiveController.java
@@ -1,6 +1,7 @@
 package com.wanted.naeil.domain.live.controller;
 
 import com.wanted.naeil.domain.live.dto.response.LiveLectureListResponse;
+import com.wanted.naeil.domain.live.dto.response.UserLiveLectureRoomResponse;
 import com.wanted.naeil.domain.live.service.LiveLectureService;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
 import lombok.RequiredArgsConstructor;
@@ -99,4 +100,34 @@ public class UserLiveController {
         return "redirect:" + redirectPath;
 
     }
+
+    @GetMapping("/{liveId}/room")
+    public ModelAndView liveLectureRoomPage(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long liveId,
+            ModelAndView mv,
+            RedirectAttributes redirectAttributes
+    ) {
+        if (authDetails == null) {
+            throw new AccessDeniedException("로그인 후 입장할 수 있습니다.");
+        }
+
+        Long userId = authDetails.getLoginUserDTO().getUserId();
+
+        try {
+            UserLiveLectureRoomResponse response =
+                    liveLectureService.getUserLiveLectureRoom(userId, liveId);
+
+            mv.addObject("user", authDetails.getLoginUserDTO());
+            mv.addObject("liveCourse", response);
+            mv.setViewName("live/liveLectureRoom");
+
+            return mv;
+        } catch (IllegalStateException | IllegalArgumentException | AccessDeniedException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            mv.setViewName("redirect:/my-courses");
+            return mv;
+        }
+    }
+
 }

--- a/src/main/java/com/wanted/naeil/domain/live/dto/response/InstructorLiveReservationResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/live/dto/response/InstructorLiveReservationResponse.java
@@ -1,0 +1,29 @@
+package com.wanted.naeil.domain.live.dto.response;
+
+import com.wanted.naeil.domain.live.entity.LiveReservation;
+import com.wanted.naeil.domain.live.entity.enums.LiveReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InstructorLiveReservationResponse {
+
+    private Long reservationId;
+    private String studentName;
+    private String email;
+    private LiveReservationStatus status;
+    private LocalDateTime reservedAt;
+
+    public static InstructorLiveReservationResponse of(LiveReservation reservation) {
+        return InstructorLiveReservationResponse.builder()
+                .reservationId(reservation.getId())
+                .studentName(reservation.getUser().getName())
+                .email(reservation.getUser().getEmail())
+                .status(reservation.getStatus())
+                .reservedAt(reservation.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/live/dto/response/UserLiveLectureRoomResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/live/dto/response/UserLiveLectureRoomResponse.java
@@ -1,0 +1,41 @@
+package com.wanted.naeil.domain.live.dto.response;
+
+import com.wanted.naeil.domain.live.entity.LiveLecture;
+import com.wanted.naeil.domain.live.entity.enums.LiveLectureStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserLiveLectureRoomResponse {
+
+    private Long liveId;
+    private LiveLectureStatus status;
+    private String title;
+    private String description;
+    private String instructorName;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private String streamingUrl;
+    private int currentCount;
+    private int maxCapacity;
+    private boolean liveNow;
+
+    public static UserLiveLectureRoomResponse of(LiveLecture liveLecture, boolean liveNow) {
+        return UserLiveLectureRoomResponse.builder()
+                .liveId(liveLecture.getId())
+                .status(liveLecture.getStatus())
+                .title(liveLecture.getTitle())
+                .description(liveLecture.getDescription())
+                .instructorName(liveLecture.getInstructor().getName())
+                .startAt(liveLecture.getStartAt())
+                .endAt(liveLecture.getEndAt())
+                .streamingUrl(liveLecture.getStreamingUrl())
+                .currentCount(liveLecture.getCurrentCount())
+                .maxCapacity(liveLecture.getMaxCapacity())
+                .liveNow(liveNow)
+                .build();
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/live/entity/LiveLecture.java
+++ b/src/main/java/com/wanted/naeil/domain/live/entity/LiveLecture.java
@@ -80,6 +80,15 @@ public class LiveLecture extends BaseTimeEntity {
         this.currentCount++;
     }
 
+    // 예약 인원 감소
+    public void decrementReservation() {
+        if (this.currentCount <= 0) {
+            throw new IllegalStateException("예약 인원이 이미 0명입니다.");
+        }
+
+        this.currentCount--;
+    }
+
     // 상태 변경 메서드
     public void changeStatus(LiveLectureStatus status) {
         this.status = status;

--- a/src/main/java/com/wanted/naeil/domain/live/repository/LiveReservationRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/live/repository/LiveReservationRepository.java
@@ -61,6 +61,7 @@ public interface LiveReservationRepository extends JpaRepository<LiveReservation
             LiveReservationStatus status
     );
 
+    // 실시간 강의 신청한 학생들 조회
     @Query("""
     select r
     from LiveReservation r
@@ -74,4 +75,20 @@ public interface LiveReservationRepository extends JpaRepository<LiveReservation
             @Param("status") LiveReservationStatus status
     );
 
+
+    // 실시간 강의 예매 검증
+    @Query("""
+    select r
+    from LiveReservation r
+    join fetch r.liveLecture l
+    join fetch l.instructor
+    where r.user.id = :userId
+      and l.id = :liveId
+      and r.status = :status
+    """)
+    Optional<LiveReservation> findReservedLiveRoomByUserIdAndLiveId(
+            @Param("userId") Long userId,
+            @Param("liveId") Long liveId,
+            @Param("status") LiveReservationStatus status
+    );
 }

--- a/src/main/java/com/wanted/naeil/domain/live/repository/LiveReservationRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/live/repository/LiveReservationRepository.java
@@ -7,15 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public interface LiveReservationRepository extends JpaRepository<LiveReservation, Long> {
-
-    boolean existsByUser_IdAndLiveLecture_IdAndStatus(
-            Long userId,
-            Long liveId,
-            LiveReservationStatus status
-    );
 
     @Query("""
         select r.liveLecture.id
@@ -42,4 +38,40 @@ public interface LiveReservationRepository extends JpaRepository<LiveReservation
             @Param("user") User user,
             @Param("status") LiveReservationStatus status
     );
+
+    // 현재 사용자가 예약 중인지 확인
+    Optional<LiveReservation> findByUserIdAndLiveLectureIdAndStatus(
+            Long userId,
+            Long liveId,
+            LiveReservationStatus status
+    );
+
+    // 같은 강의 취소 횟수 계산
+    long countByUserIdAndLiveLectureIdAndStatus(
+            Long userId,
+            Long liveId,
+            LiveReservationStatus status
+    );
+
+    // 사용자가 해당 실시간 강의를 CANCELED 상태로 가진 예약 중,
+    // 가장 최근에 취소된 예약 1건을 가져온다.
+    Optional<LiveReservation> findTopByUserIdAndLiveLectureIdAndStatusOrderByUpdatedAtDesc(
+            Long userId,
+            Long liveId,
+            LiveReservationStatus status
+    );
+
+    @Query("""
+    select r
+    from LiveReservation r
+    join fetch r.user
+    where r.liveLecture.id = :liveId
+      and r.status = :status
+    order by r.createdAt desc
+    """)
+    List<LiveReservation> findByLiveLectureIdAndStatusWithUserOrderByCreatedAtDesc(
+            @Param("liveId") Long liveId,
+            @Param("status") LiveReservationStatus status
+    );
+
 }

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -1,10 +1,13 @@
 package com.wanted.naeil.domain.live.service;
 
 import com.wanted.naeil.domain.admin.entity.AdminApproval;
+import com.wanted.naeil.domain.admin.entity.BlacklistHistory;
 import com.wanted.naeil.domain.admin.repository.AdminApprovalRepository;
+import com.wanted.naeil.domain.admin.repository.BlacklistRepository;
 import com.wanted.naeil.domain.live.dto.request.CreateLiveLectureRequest;
 import com.wanted.naeil.domain.live.dto.response.InstructorLiveDetailResponse;
 import com.wanted.naeil.domain.live.dto.response.InstructorLiveLectureResponse;
+import com.wanted.naeil.domain.live.dto.response.InstructorLiveReservationResponse;
 import com.wanted.naeil.domain.live.dto.response.LiveLectureListResponse;
 import com.wanted.naeil.domain.live.entity.LiveLecture;
 import com.wanted.naeil.domain.live.entity.LiveReservation;
@@ -23,10 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +35,7 @@ public class LiveLectureService {
 
     private final LiveLectureRepository liveLectureRepository;
     private final LiveReservationRepository liveReservationRepository;
+    private final BlacklistRepository bblacklistRepository;
     private final UserRepository userRepository;
     private final AdminApprovalRepository adminApprovalRepository;
 
@@ -238,15 +239,17 @@ public class LiveLectureService {
             throw new AccessDeniedException("강의를 예약하려면 로그인을 해주세요.");
         }
 
-        boolean alreadyReserved = liveReservationRepository.existsByUser_IdAndLiveLecture_IdAndStatus(
-                userId,
-                liveId,
-                LiveReservationStatus.RESERVED
-        );
+        boolean alreadyReserved = liveReservationRepository
+                .findByUserIdAndLiveLectureIdAndStatus(
+                        userId, liveId, LiveReservationStatus.RESERVED)
+                .isPresent();
 
         if (alreadyReserved) {
             throw new IllegalStateException("이미 예약하신 강의입니다.");
         }
+
+        // 10초 검증 로직
+        validateReReservationDelay(userId, liveId);
 
         // 예약 시간 검증
         validateLiveLectureReservable(liveLecture);
@@ -263,8 +266,99 @@ public class LiveLectureService {
         log.info("[LiveLectureReserve] 실시간 강의 예약 완료 - userId: {}, liveId: {}", userId, liveId);
     }
 
+    // 실시간 강의 취소 기능 - 유저
+    @Transactional
+    public void cancelLiveLectureReservation(Long userId, Long liveId) {
+
+        log.info("[LiveLectureCancel] 실시간 강의 예약 취소 시작 - userId: {}, liveId: {}", userId, liveId);
+
+        // 내 예약 조회
+        LiveReservation reservation = liveReservationRepository
+                .findByUserIdAndLiveLectureIdAndStatus(userId, liveId, LiveReservationStatus.RESERVED)
+                .orElseThrow(() -> new IllegalArgumentException("예약된 실시간 강의를 찾을 수 없습니다."));
+
+        User user = reservation.getUser();
+        LiveLecture liveLecture = reservation.getLiveLecture();
+
+        LocalDateTime createdAt = reservation.getCreatedAt();
+
+        // null 처리
+        if (createdAt == null) {
+            throw new IllegalStateException("예약 생성 시간이 없어 취소할 수 없습니다.");
+        }
+
+        // 테스트를 위해, 10초 뒤 취소 가능! 원래는 30분입니다!
+        LocalDateTime cancelAvailableAt = createdAt.plusSeconds(10);
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(cancelAvailableAt)) {
+            throw new IllegalStateException("예약 후 10초가 지나야 취소할 수 있습니다.");
+        }
+
+        long cancelCount =
+                liveReservationRepository.countByUserIdAndLiveLectureIdAndStatus(
+                        userId, liveId, LiveReservationStatus.CANCELED
+                ) + 1;
+
+        reservation.cancel();
+        // 인원 감소
+        liveLecture.decrementReservation();
+        // user 테이블 경고 올리기
+        user.increaseWarningCount();
+
+        if (cancelCount >= 3) {
+            user.ban();
+
+            BlacklistHistory history = BlacklistHistory.builder()
+                    .user(user)
+                    .admin(null)
+                    .reason("같은 실시간 강의 예약을 3회 취소하여 자동 블랙리스트 등록")
+                    .build();
+
+            bblacklistRepository.save(history);
+        }
+
+        log.info("[LiveLectureCancel] 실시간 강의 예약 취소 완료 - userId: {}, liveId: {}, cancelCount: {}",
+                userId, liveId, cancelCount);
+    }
+
+    // 실시간 강의 조회 - 강사
+    @Transactional(readOnly = true)
+    public List<InstructorLiveReservationResponse> getInstructorLiveReservations(
+            Long loginUserId, Long liveId) {
+
+        log.info("[LiveReservationList] 실시간 강의 예약자 목록 조회 Service 시작 - instructorId: {}, liveId: {}",
+                loginUserId, liveId);
+
+        User loginUser = userRepository.findById(loginUserId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다. ID: " + loginUserId));
+
+        LiveLecture liveLecture = liveLectureRepository.findById(liveId)
+                .orElseThrow(() -> new IllegalArgumentException("실시간 강의를 찾을 수 없습니다. ID: " + liveId));
+
+        validateLiveLectureReservationReadable(loginUser, liveLecture);
+
+        return liveReservationRepository
+                .findByLiveLectureIdAndStatusWithUserOrderByCreatedAtDesc(
+                        liveId, LiveReservationStatus.RESERVED).stream()
+                .map(InstructorLiveReservationResponse::of)
+                .toList();
+    }
 
     // ====== 내부 편의 메서드 =======
+
+    // 관리자, 강사 권한 체크
+    private void validateLiveLectureReservationReadable(User loginUser, LiveLecture liveLecture) {
+        if (loginUser.getRole() == Role.ADMIN) {
+            return;
+        }
+        if (loginUser.getRole() == Role.INSTRUCTOR
+                && liveLecture.getInstructor().getId().equals(loginUser.getId())) {
+            return;
+        }
+        throw new AccessDeniedException("해당 실시간 강의 예약자 목록을 조회할 권한이 없습니다.");
+    }
+
 
     // 강의 예약 변환 메서드
     private LiveLectureListResponse toLiveLectureListResponse(
@@ -300,6 +394,40 @@ public class LiveLectureService {
         );
     }
 
+    // 재예약시 방어시간 검증 로직
+    private void validateReReservationDelay(Long userId, Long liveId) {
+        // 취소가 있다면, 취소 중 최근 1건 가져오기
+        Optional<LiveReservation> lastCanceledReservation =
+                liveReservationRepository.findTopByUserIdAndLiveLectureIdAndStatusOrderByUpdatedAtDesc(
+                        userId,
+                        liveId,
+                        LiveReservationStatus.CANCELED
+                );
+
+        if (lastCanceledReservation.isEmpty()) {
+            return;
+        }
+
+        LiveReservation canceledReservation = lastCanceledReservation.get();
+
+        // 가장 최근 업데이트 시간 가져오기
+        LocalDateTime canceledAt = canceledReservation.getUpdatedAt();
+
+        if (canceledAt == null) {
+            canceledAt = canceledReservation.getCreatedAt();
+        }
+
+        if (canceledAt == null) {
+            return;
+        }
+
+        LocalDateTime reReservationAvailableAt = canceledAt.plusSeconds(10);
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(reReservationAvailableAt)) {
+            throw new IllegalStateException("예약 취소 후 10초가 지나야 다시 신청할 수 있습니다.");
+        }
+    }
 
     // 실시간 강의 등록 시간값 검증
     private void validateLiveLectureTime(CreateLiveLectureRequest request) {

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -5,10 +5,7 @@ import com.wanted.naeil.domain.admin.entity.BlacklistHistory;
 import com.wanted.naeil.domain.admin.repository.AdminApprovalRepository;
 import com.wanted.naeil.domain.admin.repository.BlacklistRepository;
 import com.wanted.naeil.domain.live.dto.request.CreateLiveLectureRequest;
-import com.wanted.naeil.domain.live.dto.response.InstructorLiveDetailResponse;
-import com.wanted.naeil.domain.live.dto.response.InstructorLiveLectureResponse;
-import com.wanted.naeil.domain.live.dto.response.InstructorLiveReservationResponse;
-import com.wanted.naeil.domain.live.dto.response.LiveLectureListResponse;
+import com.wanted.naeil.domain.live.dto.response.*;
 import com.wanted.naeil.domain.live.entity.LiveLecture;
 import com.wanted.naeil.domain.live.entity.LiveReservation;
 import com.wanted.naeil.domain.live.entity.enums.LiveLectureStatus;
@@ -344,6 +341,48 @@ public class LiveLectureService {
                 .map(InstructorLiveReservationResponse::of)
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public UserLiveLectureRoomResponse getUserLiveLectureRoom(Long userId, Long liveId) {
+        log.info("[LiveLectureRoom] 실시간 강의 입장 상세 조회 시작 - userId: {}, liveId: {}", userId, liveId);
+
+        LiveReservation reservation = liveReservationRepository
+                .findReservedLiveRoomByUserIdAndLiveId(
+                        userId,
+                        liveId,
+                        LiveReservationStatus.RESERVED
+                )
+                .orElseThrow(() -> new AccessDeniedException("예약한 실시간 강의만 입장할 수 있습니다."));
+
+        LiveLecture liveLecture = reservation.getLiveLecture();
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startAt = liveLecture.getStartAt();
+        LocalDateTime endAt = liveLecture.getEndAt();
+
+        if (startAt == null || endAt == null) {
+            throw new IllegalStateException("실시간 강의 시간이 등록되지 않았습니다.");
+        }
+
+        if (now.isBefore(startAt)) {
+            throw new IllegalStateException("아직 실시간 강의가 시작되지 않았습니다.");
+        }
+
+        if (!now.isBefore(endAt)) {
+            throw new IllegalStateException("이미 종료된 실시간 강의입니다.");
+        }
+
+        LiveLectureStatus status = liveLecture.getStatus();
+
+        if (status != LiveLectureStatus.APPROVED && status != LiveLectureStatus.IN_PROGRESS) {
+            throw new IllegalStateException("입장 가능한 실시간 강의 상태가 아닙니다.");
+        }
+
+        log.info("[LiveLectureRoom] 실시간 강의 입장 상세 조회 완료 - userId: {}, liveId: {}", userId, liveId);
+
+        return UserLiveLectureRoomResponse.of(liveLecture, true);
+    }
+
 
     // ====== 내부 편의 메서드 =======
 

--- a/src/main/java/com/wanted/naeil/domain/user/entity/User.java
+++ b/src/main/java/com/wanted/naeil/domain/user/entity/User.java
@@ -98,11 +98,8 @@ public class User extends BaseTimeEntity {
 
     // 비즈니스 로직
     // 경고 올리기
-    public void addWarning() {
+    public void increaseWarningCount() {
         this.warningCount++;
-        if (this.warningCount >= 3) {
-            this.status = UserStatus.BANNED; // 경고 3회 누적 시 정지 (예시)
-        }
     }
 
     // role 값 바꾸기

--- a/src/main/resources/templates/live/liveLectureDetail.html
+++ b/src/main/resources/templates/live/liveLectureDetail.html
@@ -3,502 +3,415 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>실시간 강의 상세 | Nae-Il</title>
+    <title>실시간 강의 | Nae-Il</title>
 
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
 
     <style>
-        body {
-            background-color: #f8fafc;
+        .line-clamp-2 {
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
         }
 
-        .tab-panel {
+        .modal-overlay {
             display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, .5);
+            z-index: 9999;
+            align-items: center;
+            justify-content: center;
         }
 
-        .tab-panel.active {
-            display: block;
+        .modal-overlay.open {
+            display: flex;
         }
     </style>
 </head>
 
-<body>
-<div th:replace="~{fragments/instructorHeader :: instructorHeader}"></div>
+<body class="bg-white text-gray-900">
 
-<div class="max-w-6xl mx-auto px-6 py-12"
-     th:attr="data-live-id=${liveCourse.liveId}">
+<div th:replace="~{fragments/userHeader :: userHeader}"></div>
 
-
-    <a th:href="@{/instructor/course-management}"
-       href="/instructor/course-management"
-       class="inline-flex items-center gap-2 text-gray-600 hover:text-blue-600 transition-colors mb-6">
-        <i class="fa-solid fa-arrow-left text-sm"></i>
-        <span class="text-sm font-bold">이전으로</span>
-    </a>
+<div class="max-w-7xl mx-auto px-6 py-12">
 
     <div class="mb-8">
-        <div class="flex items-start justify-between gap-6 mb-4">
-            <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-3 mb-3">
-                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
-                          class="px-3 py-1 bg-yellow-100 text-yellow-700 rounded-full text-sm font-bold">
-                        승인 대기
-                    </span>
+        <a th:href="@{/dashboard}"
+           href="/dashboard"
+           class="inline-flex items-center gap-2 text-gray-600 hover:text-blue-600 transition-colors">
+            <i class="fa-solid fa-chevron-left text-xs"></i>
+            <span class="text-sm font-medium">이전으로</span>
+        </a>
+    </div>
 
-                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
-                          class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-bold">
-                        승인 완료
-                    </span>
+    <header class="mb-12">
+        <h1 class="text-4xl font-black text-gray-900 mb-3">실시간 강의</h1>
+        <p class="text-lg text-gray-600 font-medium">강사와 함께하는 라이브 세션</p>
+    </header>
 
-                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'REJECTED'}"
-                          class="px-3 py-1 bg-red-100 text-red-700 rounded-full text-sm font-bold">
-                        반려됨
-                    </span>
-
-                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'IN_PROGRESS'}"
-                          class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
-                        방송 중
-                    </span>
-
-                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'ENDED'}"
-                          class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
-                        종료됨
-                    </span>
-
-                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'CANCELLED'}"
-                          class="px-3 py-1 bg-orange-100 text-orange-700 rounded-full text-sm font-bold">
-                        요청 취소
-                    </span>
-
-                    <span th:if="${liveCourse.status == null}"
-                          class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
-                        상태 없음
-                    </span>
-                </div>
-
-                <h1 class="text-4xl font-black text-gray-900 mb-3 truncate"
-                    th:text="${liveCourse.title}">
-                    실시간 강의명
-                </h1>
-
-                <p class="text-gray-500 font-medium">
-                    실시간 강의 정보와 예약생 현황을 확인할 수 있습니다.
+    <section class="mb-14 rounded-2xl bg-gradient-to-br from-blue-500 via-teal-500 to-green-500 p-10 text-white shadow-sm">
+        <div class="flex items-center justify-between gap-8">
+            <div>
+                <h2 class="text-3xl font-black mb-4">실시간 강의 예약</h2>
+                <p class="text-white/90 text-lg mb-6">
+                    강사와 직접 소통하며 학습할 수 있는 라이브 세션입니다.
                 </p>
+
+                <ul class="space-y-3 text-sm text-white/95 font-medium">
+                    <li class="flex items-center gap-3">
+                        <span class="w-1.5 h-1.5 bg-white rounded-full inline-block"></span>
+                        실시간 Q&amp;A 및 코드 리뷰
+                    </li>
+                    <li class="flex items-center gap-3">
+                        <span class="w-1.5 h-1.5 bg-white rounded-full inline-block"></span>
+                        소규모 그룹으로 진행
+                    </li>
+                    <li class="flex items-center gap-3">
+                        <span class="w-1.5 h-1.5 bg-white rounded-full inline-block"></span>
+                        녹화 영상 제공
+                    </li>
+                </ul>
             </div>
 
-            <a th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
-               th:href="@{/instructor/live-lecture/{id}/edit(id=${liveCourse.liveId})}"
-               href="/instructor/live-lecture/1/edit"
-               class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-xl transition-all font-bold">
-                <i class="fa-solid fa-pen text-sm"></i>
-                수정하기
-            </a>
+            <div class="hidden lg:flex h-28 w-28 items-center justify-center rounded-3xl bg-white/20">
+                <i class="fa-solid fa-video text-5xl text-white"></i>
+            </div>
         </div>
-    </div>
+    </section>
 
-    <div class="mb-8">
-        <div class="flex gap-2 border-b-2 border-gray-200">
-            <button type="button"
-                    onclick="switchTab('info')"
-                    id="tab-btn-info"
-                    class="px-6 py-3 font-bold transition-all text-blue-600 border-b-2 border-blue-600 -mb-[2px]">
-                강의 조회
-            </button>
+    <section th:if="${sessions != null and not #lists.isEmpty(sessions)}"
+             class="grid grid-cols-1 lg:grid-cols-2 gap-7">
 
-            <button type="button"
-                    onclick="switchTab('reservations')"
-                    id="tab-btn-reservations"
-                    class="px-6 py-3 font-bold transition-all text-gray-600 hover:text-gray-900">
-                예약생 조회
-            </button>
-        </div>
-    </div>
+        <article th:each="liveLecture : ${sessions}"
+                 class="live-lecture-card overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all hover:border-blue-300 hover:shadow-xl"
+                 th:data-live-id="${liveLecture.liveId}"
+                 th:data-title="${liveLecture.title}"
+                 th:data-start-at="${liveLecture.startAt}"
+                 th:data-end-at="${liveLecture.endAt}"
+                 th:data-my-reserved="${liveLecture.myReserved}"
+                 th:data-reservable="${liveLecture.reservable}"
+                 th:data-full="${liveLecture.full}">
 
-    <div id="tab-info" class="tab-panel active">
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            <div class="p-7">
+                <div class="mb-5 flex items-center gap-2">
+                    <span class="live-badge hidden inline-flex items-center gap-1.5 rounded-full bg-red-500 px-3 py-1.5 text-xs font-black text-white">
+                        <span class="h-2 w-2 rounded-full bg-white animate-pulse"></span>
+                        LIVE
+                    </span>
 
-            <div class="lg:col-span-2 space-y-6">
-                <div class="bg-white border-2 border-gray-200 rounded-2xl p-8 shadow-sm">
-                    <h2 class="text-2xl font-black text-gray-900 mb-6">강의 정보</h2>
-
-                    <div class="space-y-7">
-                        <div>
-                            <h3 class="text-sm font-bold text-gray-600 mb-2">강의 제목</h3>
-                            <p class="text-base text-gray-900 font-bold"
-                               th:text="${liveCourse.title}">
-                                실시간 강의 제목
-                            </p>
-                        </div>
-
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <div>
-                                <h3 class="text-sm font-bold text-gray-600 mb-2">강의 시작 일시</h3>
-                                <p class="text-base text-gray-900 font-bold"
-                                   th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd HH:mm') : '-'}">
-                                    2026-04-20 19:00
-                                </p>
-                            </div>
-
-                            <div>
-                                <h3 class="text-sm font-bold text-gray-600 mb-2">강의 종료 일시</h3>
-                                <p class="text-base text-gray-900 font-bold"
-                                   th:text="${liveCourse.endAt != null ? #temporals.format(liveCourse.endAt, 'yyyy-MM-dd HH:mm') : '-'}">
-                                    2026-04-20 21:00
-                                </p>
-                            </div>
-                        </div>
-
-                        <div>
-                            <h3 class="text-sm font-bold text-gray-600 mb-2">예약 시작 일시</h3>
-                            <p class="text-base text-gray-900 font-bold"
-                               th:text="${liveCourse.reservationStartAt != null ? #temporals.format(liveCourse.reservationStartAt, 'yyyy-MM-dd HH:mm') : '-'}">
-                                2026-04-18 09:00
-                            </p>
-                        </div>
-
-                        <div>
-                            <h3 class="text-sm font-bold text-gray-600 mb-2">강의 상태</h3>
-
-                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'PENDING'}"
-                                  class="px-3 py-1 bg-yellow-100 text-yellow-700 rounded-full text-sm font-bold">
-                                승인 대기
-                            </span>
-
-                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
-                                  class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-bold">
-                                승인 완료
-                            </span>
-
-                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'REJECTED'}"
-                                  class="px-3 py-1 bg-red-100 text-red-700 rounded-full text-sm font-bold">
-                                반려됨
-                            </span>
-
-                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'IN_PROGRESS'}"
-                                  class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
-                                방송 중
-                            </span>
-
-                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'ENDED'}"
-                                  class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
-                                종료됨
-                            </span>
-
-                            <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'CANCELLED'}"
-                                  class="px-3 py-1 bg-orange-100 text-orange-700 rounded-full text-sm font-bold">
-                                요청 취소
-                            </span>
-
-                            <span th:if="${liveCourse.status == null}"
-                                  class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
-                                상태 없음
-                            </span>
-                        </div>
-
-                        <div>
-                            <h3 class="text-sm font-bold text-gray-600 mb-2">강의 내용</h3>
-                            <p class="text-base text-gray-700 leading-relaxed font-medium whitespace-pre-line"
-                               th:text="${liveCourse.description}">
-                                실시간 강의 설명
-                            </p>
-                        </div>
-
-                        <div>
-                            <h3 class="text-sm font-bold text-gray-600 mb-2">방송 URL</h3>
-                            <a th:if="${liveCourse.streamingUrl != null and !#strings.isEmpty(liveCourse.streamingUrl)}"
-                               th:href="${liveCourse.streamingUrl}"
-                               th:text="${liveCourse.streamingUrl}"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-base text-blue-600 hover:text-blue-700 font-bold break-all">
-                                https://...
-                            </a>
-
-                            <p th:if="${liveCourse.streamingUrl == null or #strings.isEmpty(liveCourse.streamingUrl)}"
-                               class="text-base text-gray-400 font-bold">
-                                등록된 방송 URL이 없습니다
-                            </p>
-                        </div>
-
-                        <div>
-                            <h3 class="text-sm font-bold text-gray-600 mb-2">생성일</h3>
-                            <p class="text-base text-gray-900 font-medium"
-                               th:text="${liveCourse.createdAt != null ? #temporals.format(liveCourse.createdAt, 'yyyy-MM-dd') : '-'}">
-                                2026-04-01
-                            </p>
-                        </div>
-                    </div>
+                    <span th:if="${liveLecture.closingSoon}"
+                          class="inline-flex items-center rounded-full bg-yellow-500 px-3 py-1.5 text-xs font-black text-white">
+                        마감임박
+                    </span>
                 </div>
-            </div>
 
-            <div class="lg:col-span-1">
-                <div class="bg-white border-2 border-gray-200 rounded-2xl p-6 shadow-sm sticky top-24">
-                    <h2 class="text-xl font-black text-gray-900 mb-6">강의 상세</h2>
-
-                    <div class="space-y-4">
-                        <div class="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
-                            <div class="w-10 h-10 bg-blue-100 rounded-xl flex items-center justify-center flex-shrink-0">
-                                <i class="fa-solid fa-calendar-check text-blue-600"></i>
-                            </div>
-
-                            <div class="flex-1 min-w-0">
-                                <p class="text-xs font-bold text-gray-600 mb-1">예약 일시</p>
-                                <p class="text-sm font-black text-gray-900"
-                                   th:text="${liveCourse.reservationStartAt != null ? #temporals.format(liveCourse.reservationStartAt, 'yyyy-MM-dd HH:mm') : '-'}">
-                                    2026-04-18 09:00
-                                </p>
-                            </div>
-                        </div>
-
-                        <div class="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
-                            <div class="w-10 h-10 bg-green-100 rounded-xl flex items-center justify-center flex-shrink-0">
-                                <i class="fa-solid fa-users text-green-600"></i>
-                            </div>
-
-                            <div class="flex-1 min-w-0">
-                                <p class="text-xs font-bold text-gray-600 mb-1">예약 현황</p>
-
-                                <p class="text-sm font-black text-gray-900">
-                                    <span th:text="${liveCourse.currentCount}">0</span>/<span th:text="${liveCourse.maxCapacity}">0</span>명
-                                </p>
-
-                                <div class="mt-2 w-full bg-gray-200 rounded-full h-2 overflow-hidden">
-                                    <div class="bg-gradient-to-r from-green-500 to-green-600 h-2 rounded-full transition-all"
-                                         th:style="${liveCourse.maxCapacity > 0 ? 'width:' + (liveCourse.currentCount * 100 / liveCourse.maxCapacity) + '%' : 'width:0%'}">
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
-                            <div class="w-10 h-10 bg-purple-100 rounded-xl flex items-center justify-center flex-shrink-0">
-                                <i class="fa-solid fa-clock text-purple-600"></i>
-                            </div>
-
-                            <div class="flex-1 min-w-0">
-                                <p class="text-xs font-bold text-gray-600 mb-1">정원</p>
-                                <p class="text-sm font-black text-gray-900">
-                                    <span th:text="${liveCourse.maxCapacity}">0</span>명
-                                </p>
-                            </div>
-                        </div>
-
-                        <div class="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
-                            <div class="w-10 h-10 bg-orange-100 rounded-xl flex items-center justify-center flex-shrink-0">
-                                <i class="fa-solid fa-video text-orange-600"></i>
-                            </div>
-
-                            <div class="flex-1 min-w-0">
-                                <p class="text-xs font-bold text-gray-600 mb-1">강의 시작</p>
-                                <p class="text-sm font-black text-gray-900"
-                                   th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd HH:mm') : '-'}">
-                                    2026-04-20 19:00
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div id="tab-reservations" class="tab-panel">
-        <div class="bg-white border-2 border-gray-200 rounded-2xl p-8 shadow-sm">
-            <div class="flex items-center justify-between mb-6">
-                <h2 class="text-2xl font-black text-gray-900">
-                    예약자 목록
-                    <span class="text-blue-600">
-                    (<span id="reservationCount">0</span>명)
-                </span>
+                <h2 class="mb-5 line-clamp-2 text-2xl font-black text-gray-900 transition-colors hover:text-blue-600"
+                    th:text="${liveLecture.title}">
+                    실시간 강의명
                 </h2>
+
+                <div class="mb-7 flex items-center gap-3">
+                    <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-indigo-500 text-white">
+                        <i class="fa-solid fa-code text-xs"></i>
+                    </div>
+
+                    <span class="text-sm font-bold text-gray-600"
+                          th:text="${liveLecture.instructorName}">
+                        강사명
+                    </span>
+                </div>
             </div>
 
-            <div id="reservationLoading" class="text-center py-16 hidden">
-                <i class="fa-solid fa-spinner fa-spin text-blue-500 text-4xl mb-4 block"></i>
-                <p class="text-gray-500 font-bold">예약자 목록을 불러오는 중입니다</p>
-            </div>
+            <div class="border-t border-gray-100 px-7 py-6">
+                <div class="mb-5 space-y-4">
+                    <div class="flex items-center gap-3 text-sm text-gray-700">
+                        <i class="fa-regular fa-calendar text-blue-600"></i>
+                        <span class="font-black">강의 날짜:</span>
+                        <span class="font-mono"
+                              th:text="${liveLecture.startAt != null ? #temporals.format(liveLecture.startAt, 'yyyy-MM-dd') : '-'}">
+                            2026-04-21
+                        </span>
+                    </div>
 
-            <div id="reservationList" class="space-y-3"></div>
+                    <div class="flex items-center gap-3 text-sm text-gray-700">
+                        <i class="fa-regular fa-clock text-blue-600"></i>
+                        <span class="font-black">강의 시간:</span>
+                        <span class="font-mono">
+                            <span th:text="${liveLecture.startAt != null ? #temporals.format(liveLecture.startAt, 'HH:mm') : '-'}">19:00</span>
+                            <span> - </span>
+                            <span th:text="${liveLecture.endAt != null ? #temporals.format(liveLecture.endAt, 'HH:mm') : '-'}">21:00</span>
+                        </span>
+                    </div>
 
-            <div id="reservationEmpty" class="text-center py-16 hidden">
-                <i class="fa-solid fa-users text-gray-300 text-5xl mb-4 block"></i>
-                <p class="text-gray-500 font-bold">예약한 수강생이 없습니다</p>
-            </div>
+                    <div class="flex items-center gap-3 text-sm text-gray-700">
+                        <i class="fa-regular fa-bell text-blue-600"></i>
+                        <span class="font-black">예약 시작:</span>
+                        <span class="font-mono"
+                              th:text="${liveLecture.reservationStartAt != null ? #temporals.format(liveLecture.reservationStartAt, 'yyyy-MM-dd HH:mm') : '-'}">
+                            2026-04-20 10:00
+                        </span>
+                    </div>
 
-            <div id="reservationError" class="text-center py-16 hidden">
-                <i class="fa-solid fa-triangle-exclamation text-red-300 text-5xl mb-4 block"></i>
-                <p class="text-red-500 font-bold">예약자 목록 조회에 실패했습니다</p>
+                    <div>
+                        <div class="mb-2 flex items-center justify-between text-sm">
+                            <div class="flex items-center gap-3 text-gray-700">
+                                <i class="fa-solid fa-users text-blue-600"></i>
+                                <span class="font-mono">
+                                    <span th:text="${liveLecture.currentCount}">0</span>/<span th:text="${liveLecture.maxCapacity}">0</span>
+                                    명 예약
+                                </span>
+                            </div>
+
+                            <span th:class="${liveLecture.closingSoon} ? 'text-xs font-mono font-black text-red-600' : 'text-xs font-mono font-bold text-gray-500'"
+                                  th:text="${liveLecture.reservationRate + '%'}">
+                                27%
+                            </span>
+                        </div>
+
+                        <div class="h-2.5 overflow-hidden rounded-full bg-gray-100">
+                            <div th:class="${liveLecture.closingSoon} ? 'h-full rounded-full bg-red-500' : (${liveLecture.reservationRate >= 50} ? 'h-full rounded-full bg-green-500' : 'h-full rounded-full bg-yellow-400')"
+                                 th:style="'width:' + ${liveLecture.reservationRate} + '%'">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="space-y-3">
+                    <a th:href="@{/live-lecture/{id}/room(id=${liveLecture.liveId})}"
+                       href="/live-lecture/1/room"
+                       class="live-enter-action hidden flex w-full items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-blue-600 to-green-600 py-4 text-center font-black text-white transition-all hover:shadow-lg">
+                        <i class="fa-solid fa-video text-sm"></i>
+                        입장하기
+                    </a>
+
+                    <button type="button"
+                            th:data-id="${liveLecture.liveId}"
+                            th:data-title="${liveLecture.title}"
+                            onclick="handleCancelReservation(this)"
+                            class="live-cancel-action hidden w-full rounded-lg border-2 border-red-300 bg-white py-4 font-black text-red-600 transition-all hover:bg-red-50">
+                        취소하기
+                    </button>
+
+                    <button type="button"
+                            th:data-id="${liveLecture.liveId}"
+                            th:data-title="${liveLecture.title}"
+                            th:data-reserved="${liveLecture.myReserved}"
+                            onclick="handleReservation(this)"
+                            class="live-reserve-action hidden w-full rounded-lg bg-blue-600 py-4 font-black text-white transition-all hover:bg-blue-700 hover:shadow-lg">
+                        예약하기
+                    </button>
+
+                    <button type="button"
+                            disabled
+                            class="live-full-action hidden w-full cursor-not-allowed rounded-lg bg-gray-100 py-4 font-black text-gray-400">
+                        마감됨
+                    </button>
+
+                    <button type="button"
+                            disabled
+                            class="live-ended-action hidden w-full cursor-not-allowed rounded-lg bg-gray-100 py-4 font-black text-gray-400">
+                        종료된 강의입니다
+                    </button>
+
+                    <button type="button"
+                            disabled
+                            class="live-unavailable-action hidden w-full cursor-not-allowed rounded-lg bg-gray-100 py-4 font-black text-gray-400">
+                        예약 불가
+                    </button>
+                </div>
             </div>
+        </article>
+    </section>
+
+    <section th:if="${sessions == null or #lists.isEmpty(sessions)}"
+             class="py-24 text-center">
+        <div class="mx-auto mb-6 flex h-28 w-28 items-center justify-center rounded-3xl bg-gray-100">
+            <i class="fa-solid fa-video text-5xl text-gray-400"></i>
+        </div>
+
+        <h3 class="mb-3 text-2xl font-black text-gray-900">예정된 실시간 강의가 없습니다</h3>
+        <p class="text-gray-500 font-medium">곧 새로운 세션이 열립니다</p>
+    </section>
+</div>
+
+<footer class="mt-20 border-t border-gray-200 bg-gray-50">
+    <div class="max-w-7xl mx-auto flex flex-col gap-4 px-6 py-8 text-sm text-gray-500 md:flex-row md:items-center md:justify-between">
+        <p class="font-medium">↗ © 2026 Nae-Il. 코딩으로 만드는 내일</p>
+
+        <div class="flex gap-6">
+            <a href="#" class="hover:text-gray-900">이용약관</a>
+            <a href="#" class="hover:text-gray-900">개인정보처리방침</a>
+            <a href="#" class="hover:text-gray-900">고객센터</a>
         </div>
     </div>
+</footer>
 
+<div id="confirmModal" class="modal-overlay">
+    <div class="bg-white rounded-2xl p-8 max-w-md w-full mx-4 shadow-xl">
+        <h3 class="text-xl font-black text-gray-900 mb-4">실시간 강의 예약</h3>
+        <p id="confirmMessage" class="text-gray-600 mb-6 font-medium">해당 강의를 예약하시겠습니까?</p>
+
+        <form id="reservationForm" method="post">
+            <div class="flex gap-3">
+                <button type="button"
+                        onclick="closeModal()"
+                        class="flex-1 px-6 py-3 border-2 border-gray-300 text-gray-700 rounded-xl hover:border-gray-400 transition-all font-bold">
+                    취소
+                </button>
+
+                <button type="submit"
+                        class="flex-1 px-6 py-3 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-lg transition-all font-bold">
+                    예약하기
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="alertModal" class="modal-overlay">
+    <div class="bg-white rounded-2xl p-8 max-w-md w-full mx-4 shadow-xl text-center">
+        <p id="alertMessage" class="text-gray-800 font-bold mb-6">이미 예약한 강의입니다</p>
+
+        <button type="button"
+                onclick="document.getElementById('alertModal').classList.remove('open')"
+                class="px-6 py-3 bg-blue-600 text-white rounded-xl font-bold hover:bg-blue-700 transition-all">
+            확인
+        </button>
+    </div>
 </div>
 
 <script>
-    const root = document.querySelector('[data-live-id]');
-    const liveId = root.dataset.liveId;
-    let reservationsLoaded = false;
-
-    function switchTab(tab) {
-        ['info', 'reservations'].forEach(t => {
-            document.getElementById('tab-' + t).classList.remove('active');
-
-            const btn = document.getElementById('tab-btn-' + t);
-            btn.className = 'px-6 py-3 font-bold transition-all text-gray-600 hover:text-gray-900';
-        });
-
-        document.getElementById('tab-' + tab).classList.add('active');
-
-        const activeBtn = document.getElementById('tab-btn-' + tab);
-        activeBtn.className = 'px-6 py-3 font-bold transition-all text-blue-600 border-b-2 border-blue-600 -mb-[2px]';
-
-        if (tab === 'reservations') {
-            loadReservations();
-        }
+    function initLiveLectureActions() {
+        updateLiveLectureActions();
+        setInterval(updateLiveLectureActions, 10000);
     }
 
-    async function loadReservations() {
+    function updateLiveLectureActions() {
+        const cards = document.querySelectorAll('.live-lecture-card');
+        const now = new Date();
 
-        showReservationLoading();
+        cards.forEach(card => {
+            const startAt = new Date(card.dataset.startAt);
+            const endAt = new Date(card.dataset.endAt);
+            const myReserved = card.dataset.myReserved === 'true';
+            const reservable = card.dataset.reservable === 'true';
+            const full = card.dataset.full === 'true';
 
-        try {
-            const response = await fetch(`/instructor/live-lecture/${liveId}/reservations`);
+            const liveBadge = card.querySelector('.live-badge');
+            const enterAction = card.querySelector('.live-enter-action');
+            const cancelAction = card.querySelector('.live-cancel-action');
+            const reserveAction = card.querySelector('.live-reserve-action');
+            const fullAction = card.querySelector('.live-full-action');
+            const endedAction = card.querySelector('.live-ended-action');
+            const unavailableAction = card.querySelector('.live-unavailable-action');
 
-            if (!response.ok) {
-                showReservationError();
+            hideElement(liveBadge);
+            hideElement(enterAction);
+            hideElement(cancelAction);
+            hideElement(reserveAction);
+            hideElement(fullAction);
+            hideElement(endedAction);
+            hideElement(unavailableAction);
+
+            if (now >= endAt) {
+                showElement(endedAction);
                 return;
             }
 
-            const reservations = await response.json();
-            renderReservations(reservations);
-            reservationsLoaded = true;
-        } catch (error) {
-            showReservationError();
-        }
-    }
+            const liveNow = now >= startAt && now < endAt;
 
-    function renderReservations(reservations) {
-        const reservationList = document.getElementById('reservationList');
-        const reservationCount = document.getElementById('reservationCount');
+            if (liveNow) {
+                showElement(liveBadge);
+            }
 
-        hideReservationStates();
+            if (myReserved && liveNow) {
+                showElement(enterAction);
+                return;
+            }
 
-        reservationCount.textContent = reservations.length;
-        reservationList.innerHTML = '';
+            if (myReserved && !liveNow) {
+                showElement(cancelAction);
+                return;
+            }
 
-        if (reservations.length === 0) {
-            document.getElementById('reservationEmpty').classList.remove('hidden');
-            return;
-        }
+            if (!myReserved && full) {
+                showElement(fullAction);
+                return;
+            }
 
-        reservations.forEach(reservation => {
-            reservationList.insertAdjacentHTML('beforeend', createReservationItem(reservation));
+            if (!myReserved && reservable) {
+                showElement(reserveAction);
+                return;
+            }
+
+            showElement(unavailableAction);
         });
     }
 
-    function createReservationItem(reservation) {
-        const statusText = getReservationStatusText(reservation.status);
-        const statusClass = getReservationStatusClass(reservation.status);
-        const reservedDate = formatDate(reservation.reservedAt);
-
-        return `
-            <div class="bg-gray-50 border-2 border-gray-200 rounded-xl p-5">
-                <div class="flex items-center justify-between">
-                    <div class="flex-1 min-w-0">
-                        <div class="flex items-center gap-3 mb-2">
-                            <h3 class="text-lg font-black text-gray-900">
-                                ${escapeHtml(reservation.studentName)}
-                            </h3>
-
-                            <span class="${statusClass}">
-                                ${statusText}
-                            </span>
-                        </div>
-
-                        <div class="flex flex-wrap items-center gap-4 text-sm">
-                            <div class="flex items-center gap-2">
-                                <i class="fa-solid fa-envelope text-gray-500 text-xs"></i>
-                                <span class="text-gray-600 font-medium">
-                                    ${escapeHtml(reservation.email)}
-                                </span>
-                            </div>
-
-                            <div class="flex items-center gap-2">
-                                <i class="fa-solid fa-calendar text-gray-500 text-xs"></i>
-                                <span class="text-gray-600 font-medium">
-                                    예약일 ${reservedDate}
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        `;
-    }
-
-    function getReservationStatusText(status) {
-        if (status === 'RESERVED') {
-            return '확정';
+    function showElement(element) {
+        if (!element) {
+            return;
         }
 
-        if (status === 'CANCELED') {
-            return '취소';
+        element.classList.remove('hidden');
+    }
+
+    function hideElement(element) {
+        if (!element) {
+            return;
         }
 
-        return '알 수 없음';
+        element.classList.add('hidden');
     }
 
-    function getReservationStatusClass(status) {
-        if (status === 'RESERVED') {
-            return 'px-2.5 py-1 bg-green-100 text-green-700 rounded-full text-xs font-bold';
+    function handleReservation(btn) {
+        const liveId = btn.dataset.id;
+        const title = btn.dataset.title;
+        const isReserved = btn.dataset.reserved === 'true';
+
+        if (isReserved) {
+            document.getElementById('alertMessage').textContent = '이미 예약한 강의입니다.';
+            document.getElementById('alertModal').classList.add('open');
+            return;
         }
 
-        if (status === 'CANCELED') {
-            return 'px-2.5 py-1 bg-red-100 text-red-700 rounded-full text-xs font-bold';
+        document.getElementById('confirmMessage').textContent = `"${title}" 강의를 예약하시겠습니까?`;
+        document.getElementById('reservationForm').action = `/live-lecture/${liveId}/reservations`;
+        document.getElementById('confirmModal').classList.add('open');
+    }
+
+    function closeModal() {
+        document.getElementById('confirmModal').classList.remove('open');
+    }
+
+    function handleCancelReservation(btn) {
+        const liveId = btn.dataset.id;
+        const title = btn.dataset.title;
+
+        if (!confirm(`"${title}" 예약을 취소하시겠습니까?`)) {
+            return;
         }
 
-        return 'px-2.5 py-1 bg-gray-100 text-gray-700 rounded-full text-xs font-bold';
+        const form = document.createElement('form');
+        form.method = 'post';
+        form.action = `/live-lecture/${liveId}/reservations/cancel`;
+
+        document.body.appendChild(form);
+        form.submit();
     }
 
-    function formatDate(dateTime) {
-        if (!dateTime) {
-            return '-';
-        }
-
-        return dateTime.substring(0, 10);
-    }
-
-    function showReservationLoading() {
-        hideReservationStates();
-        document.getElementById('reservationLoading').classList.remove('hidden');
-    }
-
-    function showReservationError() {
-        hideReservationStates();
-        document.getElementById('reservationError').classList.remove('hidden');
-    }
-
-    function hideReservationStates() {
-        document.getElementById('reservationLoading').classList.add('hidden');
-        document.getElementById('reservationEmpty').classList.add('hidden');
-        document.getElementById('reservationError').classList.add('hidden');
-    }
-
-    function escapeHtml(value) {
-        if (value === null || value === undefined) {
-            return '';
-        }
-
-        return String(value)
-            .replaceAll('&', '&amp;')
-            .replaceAll('<', '&lt;')
-            .replaceAll('>', '&gt;')
-            .replaceAll('"', '&quot;')
-            .replaceAll("'", '&#039;');
-    }
+    initLiveLectureActions();
 </script>
 
+<script th:if="${errorMessage != null}" th:inline="javascript">
+    alert([[${errorMessage}]]);
+</script>
+
+<script th:if="${message != null}" th:inline="javascript">
+    alert([[${message}]]);
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/live/liveLectureDetail.html
+++ b/src/main/resources/templates/live/liveLectureDetail.html
@@ -27,7 +27,9 @@
 <body>
 <div th:replace="~{fragments/instructorHeader :: instructorHeader}"></div>
 
-<div class="max-w-6xl mx-auto px-6 py-12">
+<div class="max-w-6xl mx-auto px-6 py-12"
+     th:attr="data-live-id=${liveCourse.liveId}">
+
 
     <a th:href="@{/instructor/course-management}"
        href="/instructor/course-management"
@@ -306,73 +308,39 @@
         <div class="bg-white border-2 border-gray-200 rounded-2xl p-8 shadow-sm">
             <div class="flex items-center justify-between mb-6">
                 <h2 class="text-2xl font-black text-gray-900">
-                    예약생 목록
+                    예약자 목록
                     <span class="text-blue-600">
-                        (<span th:text="${reservations != null ? #lists.size(reservations) : 0}">0</span>명)
-                    </span>
+                    (<span id="reservationCount">0</span>명)
+                </span>
                 </h2>
             </div>
 
-            <div th:if="${reservations != null and not #lists.isEmpty(reservations)}" class="space-y-3">
-                <div th:each="reservation : ${reservations}"
-                     class="bg-gray-50 border-2 border-gray-200 rounded-xl p-5">
-                    <div class="flex items-center justify-between">
-                        <div class="flex-1 min-w-0">
-                            <div class="flex items-center gap-3 mb-2">
-                                <h3 class="text-lg font-black text-gray-900"
-                                    th:text="${reservation.name}">
-                                    예약자 이름
-                                </h3>
-
-                                <span th:if="${reservation.status != null and reservation.status.name() == 'RESERVED'}"
-                                      class="px-2.5 py-1 bg-green-100 text-green-700 rounded-full text-xs font-bold">
-                                    예약 완료
-                                </span>
-
-                                <span th:if="${reservation.status != null and reservation.status.name() == 'CANCELED'}"
-                                      class="px-2.5 py-1 bg-red-100 text-red-700 rounded-full text-xs font-bold">
-                                    취소됨
-                                </span>
-
-                                <span th:if="${reservation.status == null}"
-                                      class="px-2.5 py-1 bg-gray-100 text-gray-700 rounded-full text-xs font-bold">
-                                    상태 없음
-                                </span>
-                            </div>
-
-                            <div class="flex flex-wrap items-center gap-4 text-sm">
-                                <div class="flex items-center gap-2">
-                                    <i class="fa-solid fa-envelope text-gray-500 text-xs"></i>
-                                    <span class="text-gray-600 font-medium"
-                                          th:text="${reservation.email}">
-                                        user@example.com
-                                    </span>
-                                </div>
-
-                                <div class="flex items-center gap-2">
-                                    <i class="fa-solid fa-calendar text-gray-500 text-xs"></i>
-                                    <span class="text-gray-600 font-medium">
-                                        예약일:
-                                        <span th:text="${reservation.reservedAt != null ? #temporals.format(reservation.reservedAt, 'yyyy-MM-dd HH:mm') : '-'}">
-                                            2026-04-18 10:00
-                                        </span>
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <div id="reservationLoading" class="text-center py-16 hidden">
+                <i class="fa-solid fa-spinner fa-spin text-blue-500 text-4xl mb-4 block"></i>
+                <p class="text-gray-500 font-bold">예약자 목록을 불러오는 중입니다</p>
             </div>
 
-            <div th:if="${reservations == null or #lists.isEmpty(reservations)}" class="text-center py-16">
+            <div id="reservationList" class="space-y-3"></div>
+
+            <div id="reservationEmpty" class="text-center py-16 hidden">
                 <i class="fa-solid fa-users text-gray-300 text-5xl mb-4 block"></i>
                 <p class="text-gray-500 font-bold">예약한 수강생이 없습니다</p>
             </div>
+
+            <div id="reservationError" class="text-center py-16 hidden">
+                <i class="fa-solid fa-triangle-exclamation text-red-300 text-5xl mb-4 block"></i>
+                <p class="text-red-500 font-bold">예약자 목록 조회에 실패했습니다</p>
+            </div>
         </div>
     </div>
+
 </div>
 
 <script>
+    const root = document.querySelector('[data-live-id]');
+    const liveId = root.dataset.liveId;
+    let reservationsLoaded = false;
+
     function switchTab(tab) {
         ['info', 'reservations'].forEach(t => {
             document.getElementById('tab-' + t).classList.remove('active');
@@ -385,7 +353,152 @@
 
         const activeBtn = document.getElementById('tab-btn-' + tab);
         activeBtn.className = 'px-6 py-3 font-bold transition-all text-blue-600 border-b-2 border-blue-600 -mb-[2px]';
+
+        if (tab === 'reservations') {
+            loadReservations();
+        }
+    }
+
+    async function loadReservations() {
+
+        showReservationLoading();
+
+        try {
+            const response = await fetch(`/instructor/live-lecture/${liveId}/reservations`);
+
+            if (!response.ok) {
+                showReservationError();
+                return;
+            }
+
+            const reservations = await response.json();
+            renderReservations(reservations);
+            reservationsLoaded = true;
+        } catch (error) {
+            showReservationError();
+        }
+    }
+
+    function renderReservations(reservations) {
+        const reservationList = document.getElementById('reservationList');
+        const reservationCount = document.getElementById('reservationCount');
+
+        hideReservationStates();
+
+        reservationCount.textContent = reservations.length;
+        reservationList.innerHTML = '';
+
+        if (reservations.length === 0) {
+            document.getElementById('reservationEmpty').classList.remove('hidden');
+            return;
+        }
+
+        reservations.forEach(reservation => {
+            reservationList.insertAdjacentHTML('beforeend', createReservationItem(reservation));
+        });
+    }
+
+    function createReservationItem(reservation) {
+        const statusText = getReservationStatusText(reservation.status);
+        const statusClass = getReservationStatusClass(reservation.status);
+        const reservedDate = formatDate(reservation.reservedAt);
+
+        return `
+            <div class="bg-gray-50 border-2 border-gray-200 rounded-xl p-5">
+                <div class="flex items-center justify-between">
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-3 mb-2">
+                            <h3 class="text-lg font-black text-gray-900">
+                                ${escapeHtml(reservation.studentName)}
+                            </h3>
+
+                            <span class="${statusClass}">
+                                ${statusText}
+                            </span>
+                        </div>
+
+                        <div class="flex flex-wrap items-center gap-4 text-sm">
+                            <div class="flex items-center gap-2">
+                                <i class="fa-solid fa-envelope text-gray-500 text-xs"></i>
+                                <span class="text-gray-600 font-medium">
+                                    ${escapeHtml(reservation.email)}
+                                </span>
+                            </div>
+
+                            <div class="flex items-center gap-2">
+                                <i class="fa-solid fa-calendar text-gray-500 text-xs"></i>
+                                <span class="text-gray-600 font-medium">
+                                    예약일 ${reservedDate}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    function getReservationStatusText(status) {
+        if (status === 'RESERVED') {
+            return '확정';
+        }
+
+        if (status === 'CANCELED') {
+            return '취소';
+        }
+
+        return '알 수 없음';
+    }
+
+    function getReservationStatusClass(status) {
+        if (status === 'RESERVED') {
+            return 'px-2.5 py-1 bg-green-100 text-green-700 rounded-full text-xs font-bold';
+        }
+
+        if (status === 'CANCELED') {
+            return 'px-2.5 py-1 bg-red-100 text-red-700 rounded-full text-xs font-bold';
+        }
+
+        return 'px-2.5 py-1 bg-gray-100 text-gray-700 rounded-full text-xs font-bold';
+    }
+
+    function formatDate(dateTime) {
+        if (!dateTime) {
+            return '-';
+        }
+
+        return dateTime.substring(0, 10);
+    }
+
+    function showReservationLoading() {
+        hideReservationStates();
+        document.getElementById('reservationLoading').classList.remove('hidden');
+    }
+
+    function showReservationError() {
+        hideReservationStates();
+        document.getElementById('reservationError').classList.remove('hidden');
+    }
+
+    function hideReservationStates() {
+        document.getElementById('reservationLoading').classList.add('hidden');
+        document.getElementById('reservationEmpty').classList.add('hidden');
+        document.getElementById('reservationError').classList.add('hidden');
+    }
+
+    function escapeHtml(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+
+        return String(value)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#039;');
     }
 </script>
+
 </body>
 </html>

--- a/src/main/resources/templates/live/liveLectureList.html
+++ b/src/main/resources/templates/live/liveLectureList.html
@@ -300,9 +300,28 @@
     }
 
     function handleCancelReservation(btn) {
+        const liveId = btn.dataset.id;
         const title = btn.dataset.title;
-        alert(`"${title}" 예약 취소 기능은 아직 준비 중입니다.`);
+
+        if (!confirm(`"${title}" 예약을 취소하시겠습니까?`)) {
+            return;
+        }
+
+        const form = document.createElement('form');
+        form.method = 'post';
+        form.action = `/live-lecture/${liveId}/reservations/cancel`;
+
+        document.body.appendChild(form);
+        form.submit();
     }
+
+</script>
+<script th:if="${errorMessage != null}" th:inline="javascript">
+    alert([[${errorMessage}]]);
+</script>
+
+<script th:if="${message != null}" th:inline="javascript">
+    alert([[${message}]]);
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/live/liveLectureRoom.html
+++ b/src/main/resources/templates/live/liveLectureRoom.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>실시간 강의 입장 | Nae-Il</title>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
+
+    <style>
+        body {
+            background-color: #f8fafc;
+        }
+    </style>
+</head>
+
+<body>
+<div th:replace="~{fragments/userHeader :: userHeader}"></div>
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+
+    <a th:href="@{/my-courses}"
+       href="/my-courses"
+       class="inline-flex items-center gap-2 text-gray-600 hover:text-blue-600 transition-colors mb-8">
+        <i class="fa-solid fa-arrow-left text-sm"></i>
+        <span class="text-sm font-bold">뒤로가기</span>
+    </a>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+
+        <section class="lg:col-span-2 space-y-6">
+
+            <div class="bg-white border-2 border-gray-200 rounded-2xl p-8 shadow-sm">
+                <div class="flex items-center gap-3 mb-5">
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'IN_PROGRESS'}"
+                          class="inline-flex items-center gap-2 px-3 py-1.5 bg-red-100 text-red-700 rounded-full text-sm font-black">
+                        <span class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></span>
+                        LIVE 진행중
+                    </span>
+
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
+                          class="inline-flex items-center gap-2 px-3 py-1.5 bg-green-100 text-green-700 rounded-full text-sm font-black">
+                        진행 예정
+                    </span>
+
+                    <span th:if="${liveCourse.status != null and liveCourse.status.name() == 'ENDED'}"
+                          class="inline-flex items-center gap-2 px-3 py-1.5 bg-gray-100 text-gray-700 rounded-full text-sm font-black">
+                        종료됨
+                    </span>
+                </div>
+
+                <h1 class="text-4xl font-black text-gray-900 leading-tight mb-5"
+                    th:text="${liveCourse.title}">
+                    Q&A 세션: TypeScript 타입 시스템 깊게 파헤치기
+                </h1>
+
+                <div class="flex items-center gap-3 mb-8">
+                    <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-blue-600 to-green-600 flex items-center justify-center text-white shadow-md">
+                        <i class="fa-solid fa-chalkboard-user text-sm"></i>
+                    </div>
+
+                    <div>
+                        <p class="text-xs font-black text-gray-500 mb-1">강사</p>
+                        <p class="text-base font-black text-gray-900"
+                           th:text="${liveCourse.instructorName}">
+                            박타입
+                        </p>
+                    </div>
+                </div>
+
+                <div class="border-t-2 border-gray-100 pt-7">
+                    <h2 class="text-xl font-black text-gray-900 mb-4">강의 설명</h2>
+
+                    <p class="text-base text-gray-700 leading-relaxed font-medium whitespace-pre-line"
+                       th:text="${liveCourse.description}">
+                        TypeScript의 고급 타입 시스템을 심도 있게 다룹니다. 제네릭, 유틸리티 타입, 조건부 타입 등 복잡한 타입 문제를 해결하는 방법을 Q&A 형식으로 학습합니다.
+                    </p>
+                </div>
+            </div>
+
+            <div class="bg-white border-2 border-gray-200 rounded-2xl p-8 shadow-sm">
+                <div class="flex items-start justify-between gap-6">
+                    <div class="min-w-0">
+                        <h2 class="text-2xl font-black text-gray-900 mb-3">방송 링크</h2>
+                        <p class="text-gray-500 font-medium mb-5">
+                            강의 시간이 되면 아래 링크를 통해 실시간 강의에 참여할 수 있습니다.
+                        </p>
+
+                        <a th:if="${liveCourse.streamingUrl != null and !#strings.isEmpty(liveCourse.streamingUrl)}"
+                           th:href="${liveCourse.streamingUrl}"
+                           th:text="${liveCourse.streamingUrl}"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 font-black break-all">
+                            https://www.youtube.com/?gl=KR
+                        </a>
+
+                        <p th:if="${liveCourse.streamingUrl == null or #strings.isEmpty(liveCourse.streamingUrl)}"
+                           class="text-gray-400 font-bold">
+                            등록된 방송 링크가 없습니다.
+                        </p>
+                    </div>
+
+                    <div class="hidden md:flex w-16 h-16 rounded-2xl bg-blue-50 items-center justify-center flex-shrink-0">
+                        <i class="fa-solid fa-link text-blue-600 text-2xl"></i>
+                    </div>
+                </div>
+
+                <div class="mt-8">
+                    <a th:if="${liveCourse.streamingUrl != null and !#strings.isEmpty(liveCourse.streamingUrl)
+                               and liveCourse.status != null
+                               and liveCourse.status.name() == 'IN_PROGRESS'}"
+                       th:href="${liveCourse.streamingUrl}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="inline-flex w-full items-center justify-center gap-3 px-8 py-4 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-xl transition-all font-black text-lg">
+                        <i class="fa-solid fa-video"></i>
+                        실시간 강의 입장하기
+                    </a>
+
+                    <button th:if="${liveCourse.status == null or liveCourse.status.name() != 'IN_PROGRESS'}"
+                            type="button"
+                            disabled
+                            class="w-full px-8 py-4 bg-gray-100 text-gray-400 rounded-xl font-black text-lg cursor-not-allowed">
+                        아직 입장할 수 없습니다
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        <aside class="lg:col-span-1">
+            <div class="bg-white border-2 border-gray-200 rounded-2xl p-6 shadow-sm sticky top-24">
+                <h2 class="text-2xl font-black text-gray-900 mb-6">강의 상세</h2>
+
+                <div class="space-y-4">
+
+                    <div class="p-5 rounded-2xl bg-gradient-to-br from-blue-600 to-green-500 text-white">
+                        <div class="flex items-center gap-2 mb-5">
+                            <i class="fa-solid fa-users text-white/90"></i>
+                            <p class="text-sm font-black text-white/90">실시간 참여자</p>
+                        </div>
+
+                        <div class="flex items-end gap-2 mb-4">
+                            <p class="text-4xl font-black"
+                               th:text="${liveCourse.currentCount}">
+                                10
+                            </p>
+                            <p class="text-lg font-bold text-white/80 pb-1">
+                                /
+                                <span th:text="${liveCourse.maxCapacity}">25</span>명
+                            </p>
+                        </div>
+
+                        <div class="w-full h-2 bg-white/25 rounded-full overflow-hidden">
+                            <div class="h-full bg-white rounded-full"
+                                 th:style="${liveCourse.maxCapacity > 0
+                                    ? 'width:' + (liveCourse.currentCount * 100 / liveCourse.maxCapacity) + '%'
+                                    : 'width:0%'}">
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="flex items-center gap-4 p-4 bg-gray-50 rounded-xl">
+                        <div class="w-11 h-11 bg-blue-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                            <i class="fa-solid fa-calendar-days text-blue-600"></i>
+                        </div>
+
+                        <div>
+                            <p class="text-xs font-black text-gray-500 mb-1">강의 날짜</p>
+                            <p class="text-sm font-black text-gray-900"
+                               th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'yyyy-MM-dd') : '-'}">
+                                2026-04-13
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="flex items-center gap-4 p-4 bg-gray-50 rounded-xl">
+                        <div class="w-11 h-11 bg-green-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                            <i class="fa-solid fa-clock text-green-600"></i>
+                        </div>
+
+                        <div>
+                            <p class="text-xs font-black text-gray-500 mb-1">강의 시간</p>
+                            <p class="text-sm font-black text-gray-900">
+                                <span th:text="${liveCourse.startAt != null ? #temporals.format(liveCourse.startAt, 'HH:mm') : '-'}">
+                                    14:00
+                                </span>
+                                -
+                                <span th:text="${liveCourse.endAt != null ? #temporals.format(liveCourse.endAt, 'HH:mm') : '-'}">
+                                    16:00
+                                </span>
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="flex items-center gap-4 p-4 bg-gray-50 rounded-xl">
+                        <div class="w-11 h-11 bg-red-100 rounded-xl flex items-center justify-center flex-shrink-0">
+                            <i class="fa-solid fa-signal text-red-600"></i>
+                        </div>
+
+                        <div>
+                            <p class="text-xs font-black text-gray-500 mb-1">상태</p>
+
+                            <p th:if="${liveCourse.status != null and liveCourse.status.name() == 'IN_PROGRESS'}"
+                               class="inline-flex items-center gap-2 text-sm font-black text-red-600">
+                                <span class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></span>
+                                LIVE 진행중
+                            </p>
+
+                            <p th:if="${liveCourse.status != null and liveCourse.status.name() == 'APPROVED'}"
+                               class="text-sm font-black text-green-600">
+                                진행 예정
+                            </p>
+
+                            <p th:if="${liveCourse.status != null and liveCourse.status.name() == 'ENDED'}"
+                               class="text-sm font-black text-gray-600">
+                                종료됨
+                            </p>
+
+                            <p th:if="${liveCourse.status == null}"
+                               class="text-sm font-black text-gray-400">
+                                상태 없음
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="mt-8 pt-6 border-t-2 border-gray-100">
+                    <a th:href="@{/my-courses}"
+                       href="/my-courses"
+                       class="flex w-full items-center justify-center px-6 py-3 border-2 border-gray-300 rounded-xl hover:bg-gray-50 transition-all font-black text-gray-700">
+                        강의실 나가기
+                    </a>
+                </div>
+            </div>
+        </aside>
+    </div>
+</div>
+
+<footer class="mt-20 border-t border-gray-200 bg-white">
+    <div class="max-w-6xl mx-auto px-6 py-8 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-gray-500">
+        <p class="font-medium">↗ © 2026 Nae-Il. 코딩으로 만드는 내일</p>
+
+        <div class="flex items-center gap-6">
+            <a href="#" class="hover:text-gray-900 transition-colors">이용약관</a>
+            <a href="#" class="hover:text-gray-900 transition-colors">개인정보처리방침</a>
+            <a href="#" class="hover:text-gray-900 transition-colors">고객센터</a>
+        </div>
+    </div>
+</footer>
+</body>
+</html>

--- a/src/main/resources/templates/my-courses/myCourses.html
+++ b/src/main/resources/templates/my-courses/myCourses.html
@@ -118,41 +118,75 @@
     <div th:if="${not #lists.isEmpty(liveReservations)}"
          class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <div th:each="reservation : ${liveReservations}"
-           class="bg-white border-2 border-gray-200 rounded-2xl overflow-hidden hover:shadow-xl transition-all hover:border-blue-300 flex flex-col">
+           class="live-reservation-card bg-white border-2 border-gray-200 rounded-2xl overflow-hidden hover:shadow-xl transition-all hover:border-blue-300 flex flex-col"
+           th:data-start-at="${reservation.startAt}"
+           th:data-end-at="${reservation.endAt}">
+
         <div class="relative bg-gray-900 aspect-video flex flex-col justify-center px-6">
-          <div class="flex items-center gap-1.5 px-3 py-1 bg-red-500 text-white rounded-full w-fit mb-3">
-            <span class="w-2 h-2 bg-white rounded-full animate-pulse inline-block"></span>
-            <span class="text-[10px] font-bold tracking-wider">LIVE</span>
+          <div class="live-waiting-badge flex items-center gap-1.5 px-3 py-1 bg-blue-500 text-white rounded-full w-fit mb-3">
+            <span class="w-2 h-2 bg-white rounded-full inline-block"></span>
+            <span class="text-[10px] font-bold tracking-wider">예약 완료</span>
           </div>
-          <h3 class="text-lg font-bold text-white line-clamp-2" th:text="${reservation.title}">강의명</h3>
+
+          <div class="live-active-badge hidden flex items-center gap-1.5 px-3 py-1 bg-red-500 text-white rounded-full w-fit mb-3">
+            <span class="w-2 h-2 bg-white rounded-full animate-pulse inline-block"></span>
+            <span class="text-[10px] font-bold tracking-wider">LIVE 입장 가능</span>
+          </div>
+
+          <div class="live-ended-badge hidden flex items-center gap-1.5 px-3 py-1 bg-gray-500 text-white rounded-full w-fit mb-3">
+            <span class="w-2 h-2 bg-white rounded-full inline-block"></span>
+            <span class="text-[10px] font-bold tracking-wider">종료됨</span>
+          </div>
+
+          <h3 class="text-lg font-bold text-white line-clamp-2"
+              th:text="${reservation.title}">
+            강의명
+          </h3>
         </div>
+
         <div class="p-6 flex flex-col flex-grow">
           <div class="flex items-center gap-2 mb-4">
             <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center text-blue-600">
               <i class="fa-solid fa-user-tie text-xs"></i>
             </div>
-            <span class="text-sm text-gray-600 font-bold" th:text="${reservation.instructorName}">강사명</span>
+            <span class="text-sm text-gray-600 font-bold"
+                  th:text="${reservation.instructorName}">
+          강사명
+        </span>
           </div>
+
           <div class="space-y-2.5 mb-6 text-sm text-gray-500 font-medium">
             <div class="flex items-center gap-3">
               <i class="fa-solid fa-calendar text-blue-500/70 w-4"></i>
-              <span class="font-mono" th:text="${#temporals.format(reservation.startAt, 'yyyy-MM-dd')}"></span>
+              <span class="font-mono"
+                    th:text="${#temporals.format(reservation.startAt, 'yyyy-MM-dd')}">
+            2026-04-21
+          </span>
             </div>
+
             <div class="flex items-center gap-3">
               <i class="fa-solid fa-clock text-blue-500/70 w-4"></i>
               <span class="font-mono">
-                <span th:text="${#temporals.format(reservation.startAt, 'HH:mm')}"></span> ~
-                <span th:text="${#temporals.format(reservation.endAt, 'HH:mm')}"></span>
-              </span>
+            <span th:text="${#temporals.format(reservation.startAt, 'HH:mm')}">18:30</span>
+            ~
+            <span th:text="${#temporals.format(reservation.endAt, 'HH:mm')}">20:30</span>
+          </span>
             </div>
+
             <div class="flex items-center gap-3">
               <i class="fa-solid fa-users text-blue-500/70 w-4"></i>
-              <span class="font-mono"><span th:text="${reservation.currentCount}">0</span> / <span th:text="${reservation.maxCapacity}">0</span> 명 참여</span>
+              <span class="font-mono">
+            <span th:text="${reservation.currentCount}">0</span>
+            /
+            <span th:text="${reservation.maxCapacity}">0</span>
+            명 참여
+          </span>
             </div>
           </div>
+
           <form th:action="@{/live-lecture/{liveId}/reservations/cancel(liveId=${reservation.liveId})}"
                 method="post"
-                class="mt-auto">
+                class="live-cancel-action mt-auto">
             <input type="hidden" name="redirect" value="my-courses">
 
             <button type="submit"
@@ -162,6 +196,18 @@
             </button>
           </form>
 
+          <a th:href="@{/live-lecture/{liveId}/room(liveId=${reservation.liveId})}"
+             href="/live-lecture/1/room"
+             class="live-enter-action hidden mt-auto w-full py-3 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl hover:shadow-lg font-bold text-sm text-center transition-all">
+            <i class="fa-solid fa-video text-xs mr-1"></i>
+            입장하기
+          </a>
+
+          <button type="button"
+                  disabled
+                  class="live-ended-action hidden mt-auto w-full py-3 bg-gray-100 text-gray-400 rounded-xl font-bold text-sm cursor-not-allowed">
+            종료된 강의입니다
+          </button>
         </div>
       </div>
     </div>
@@ -228,6 +274,72 @@
 </div>
 
 <script>
+
+  function initLiveReservationActions() {
+    updateLiveReservationActions();
+
+    setInterval(updateLiveReservationActions, 10000);
+  }
+
+  function updateLiveReservationActions() {
+    const cards = document.querySelectorAll('.live-reservation-card');
+    const now = new Date();
+
+    cards.forEach(card => {
+      const startAt = new Date(card.dataset.startAt);
+      const endAt = new Date(card.dataset.endAt);
+
+      const cancelAction = card.querySelector('.live-cancel-action');
+      const enterAction = card.querySelector('.live-enter-action');
+      const endedAction = card.querySelector('.live-ended-action');
+
+      const waitingBadge = card.querySelector('.live-waiting-badge');
+      const activeBadge = card.querySelector('.live-active-badge');
+      const endedBadge = card.querySelector('.live-ended-badge');
+
+      hideElement(cancelAction);
+      hideElement(enterAction);
+      hideElement(endedAction);
+      hideElement(waitingBadge);
+      hideElement(activeBadge);
+      hideElement(endedBadge);
+
+      if (now < startAt) {
+        showElement(cancelAction);
+        showElement(waitingBadge);
+        return;
+      }
+
+      if (now >= startAt && now < endAt) {
+        showElement(enterAction);
+        showElement(activeBadge);
+        return;
+      }
+
+      showElement(endedAction);
+      showElement(endedBadge);
+    });
+  }
+
+  function showElement(element) {
+    if (!element) {
+      return;
+    }
+
+    element.classList.remove('hidden');
+  }
+
+  function hideElement(element) {
+    if (!element) {
+      return;
+    }
+
+    element.classList.add('hidden');
+  }
+
+  initLiveReservationActions();
+
+
   // 별점 및 모달 스크립트
   function initStars(containerId, hiddenInputId) {
     const container = document.getElementById(containerId);

--- a/src/main/resources/templates/my-courses/myCourses.html
+++ b/src/main/resources/templates/my-courses/myCourses.html
@@ -150,9 +150,18 @@
               <span class="font-mono"><span th:text="${reservation.currentCount}">0</span> / <span th:text="${reservation.maxCapacity}">0</span> 명 참여</span>
             </div>
           </div>
-          <button class="mt-auto w-full py-3 border-2 border-red-100 text-red-500 rounded-xl hover:bg-red-50 font-bold text-sm transition-colors">
-            예약 취소
-          </button>
+          <form th:action="@{/live-lecture/{liveId}/reservations/cancel(liveId=${reservation.liveId})}"
+                method="post"
+                class="mt-auto">
+            <input type="hidden" name="redirect" value="my-courses">
+
+            <button type="submit"
+                    onclick="return confirm('실시간 강의 예약을 취소하시겠습니까?')"
+                    class="w-full py-3 border-2 border-red-100 text-red-500 rounded-xl hover:bg-red-50 font-bold text-sm transition-colors">
+              예약 취소
+            </button>
+          </form>
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 실시간 강의 삭제 기능 구현 Ref #194 
- 실시간 강의 신청자 목록 조회 Ref #195 

## 💡 어떤 기능인가요?
- 실시간 강의 삭제, 강사-실시간 강의 신청자 조회 기능 구현
-


## 📝 작업 상세 내용
- [ ] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] JUnit 단위 테스트 (Controller, Service) 통과 확인
- [x] Postman을 통한 로컬 환경 API 엔드포인트 응답 테스트 완료

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 원래 강의가 시작하면 경고카운터를 그 강의의 경고 수 만큼 취소시켜야되는데.. 테이블 or 엔티티 추가가 필요해서 구현하지 못했습니다 ㅠㅠ

## ✅ 체크 리스트
- [ ] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [ ] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [ ] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #194 
- Closes #195  