### PR TITLE
강의 상세 페이지

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
@@ -217,7 +217,9 @@ public class InstCourseController {
         Long instructorId = authDetails.getLoginUserDTO().getUserId();
         mv.addObject("user", authDetails.getLoginUserDTO());
         mv.addObject("course", courseService.getInstructorCourseDetail(instructorId, courseId));
+        mv.addObject("students", courseService.getInstructorCourseStudents(instructorId, courseId));
         mv.setViewName("course/InstructorCourseDetail");
+
         return mv;
     }
 

--- a/src/main/java/com/wanted/naeil/domain/course/dto/response/InstructorCourseStudentResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/course/dto/response/InstructorCourseStudentResponse.java
@@ -1,0 +1,57 @@
+package com.wanted.naeil.domain.course.dto.response;
+
+import com.wanted.naeil.domain.learning.entity.Enrollment;
+import com.wanted.naeil.domain.learning.entity.enums.EnrollmentStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InstructorCourseStudentResponse {
+
+    private final Long userId;
+    private final String name;
+    private final String nickname;
+    private final String email;
+    private final String phone;
+    private final String profileImg;
+    private final String enrollmentStatusLabel;
+    private final int progressRate;
+    private final LocalDateTime enrolledAt;
+
+    public static InstructorCourseStudentResponse from(Enrollment enrollment) {
+        return InstructorCourseStudentResponse.builder()
+                .userId(enrollment.getUser().getId())
+                .name(enrollment.getUser().getName())
+                .nickname(enrollment.getUser().getNickname())
+                .email(enrollment.getUser().getEmail())
+                .phone(enrollment.getUser().getPhone())
+                .profileImg(enrollment.getUser().getProfileImg())
+                .enrollmentStatusLabel(toStatusLabel(enrollment.getStatus()))
+                .progressRate((int) Math.round(enrollment.getCoursesRate()))
+                .enrolledAt(enrollment.getCreatedAt())
+                .build();
+    }
+
+    public String getEnrolledDateLabel() {
+        return enrolledAt == null ? "-" : enrolledAt.toLocalDate().toString();
+    }
+
+    public String getProgressRateLabel() {
+        return progressRate + "%";
+    }
+
+    private static String toStatusLabel(EnrollmentStatus status) {
+        if (status == null) {
+            return "-";
+        }
+
+        return switch (status) {
+            case BEFORE_START -> "수강 전";
+            case IN_PROGRESS -> "수강 중";
+            case COMPLETED -> "수강 완료";
+        };
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
+++ b/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
@@ -28,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
+import com.wanted.naeil.domain.learning.repository.EnrollmentRepository;
+
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -46,6 +48,8 @@ public class CourseService {
     private final CategoryRepository categoryRepository;
     private final SectionService sectionService;
     private final ModelMapper modelMapper;
+    private final EnrollmentRepository enrollmentRepository;
+
 
     // 코스 등록 요청 - 강사
     @Transactional
@@ -364,6 +368,20 @@ public class CourseService {
         validateCourseOwner(course, instructorId);
         return getCourseDetail(courseId);
     }
+    // 강사 강의 상세 페이지 - 해당 강의를 수강 중인 수강생 목록 조회 성민수정
+    @Transactional(readOnly = true)
+    public List<InstructorCourseStudentResponse> getInstructorCourseStudents(Long instructorId, Long courseId) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 강의입니다."));
+
+        validateCourseOwner(course, instructorId);
+
+        return enrollmentRepository.findAllWithUserByCourseIdOrderByCreatedAtDesc(courseId)
+                .stream()
+                .map(InstructorCourseStudentResponse::from)
+                .toList();
+    }
+
 
     // ==== 내부 편의 메서드 ====
     private void validateCourseOwner(Course course, Long instructorId) {

--- a/src/main/java/com/wanted/naeil/domain/learning/repository/EnrollmentRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/repository/EnrollmentRepository.java
@@ -24,5 +24,17 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     """)
     Optional<EnrollmentStatus> findStatusByUserIdAndCourseId(
             @Param("userId") Long userId,
-            @Param("courseId") Long courseId);
+            @Param("courseId") Long courseId
+    );
+
+    @Query("""
+        select e
+        from Enrollment e
+        join fetch e.user u
+        where e.course.id = :courseId
+        order by e.createdAt desc
+    """)
+    List<Enrollment> findAllWithUserByCourseIdOrderByCreatedAtDesc(
+            @Param("courseId") Long courseId
+    );
 }

--- a/src/main/resources/templates/course/InstructorCourseDetail.html
+++ b/src/main/resources/templates/course/InstructorCourseDetail.html
@@ -20,9 +20,9 @@
         <i class="fa-solid fa-chevron-left text-xs"></i> 내 강의 관리로
     </a>
     <div class="flex items-center gap-2 mb-2">
-    <span class="px-3 py-1 bg-green-50 text-green-600 border border-green-200 rounded-full text-xs font-bold">
-      ✓ 내가 등록한 강의
-    </span>
+        <span class="px-3 py-1 bg-green-50 text-green-600 border border-green-200 rounded-full text-xs font-bold">
+            ✓ 내가 등록한 강의
+        </span>
     </div>
     <h1 class="text-3xl font-black text-gray-900 mb-8">강의 관리 상세</h1>
 
@@ -34,8 +34,8 @@
                  class="w-52 h-32 object-cover rounded-xl border border-gray-100 flex-shrink-0"/>
             <div class="flex-1">
                 <div class="flex items-center gap-2 mb-3">
-          <span class="px-3 py-1 bg-blue-50 text-blue-700 border border-blue-200 rounded-full text-xs font-bold"
-                th:text="${course.category}">카테고리</span>
+                    <span class="px-3 py-1 bg-blue-50 text-blue-700 border border-blue-200 rounded-full text-xs font-bold"
+                          th:text="${course.category}">카테고리</span>
                 </div>
                 <h2 class="text-2xl font-black text-gray-900 mb-2" th:text="${course.title}">강의 제목</h2>
                 <p class="text-sm text-gray-500 leading-relaxed mb-4" th:text="${course.description}">설명</p>
@@ -85,9 +85,9 @@
             <div th:if="${course.sections != null and not #lists.isEmpty(course.sections)}" class="space-y-3 mb-8">
                 <div th:each="section, stat : ${course.sections}"
                      class="flex items-center gap-4 p-4 rounded-xl border border-gray-100 hover:bg-gray-50 transition">
-          <span class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-blue-50 text-blue-600 rounded-xl text-sm font-black border border-blue-100">
-            <span th:text="${stat.index + 1} + '주'">1주</span>
-          </span>
+                    <span class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-blue-50 text-blue-600 rounded-xl text-sm font-black border border-blue-100">
+                        <span th:text="${stat.index + 1} + '주'">1주</span>
+                    </span>
                     <div class="flex-1">
                         <p class="font-semibold text-gray-900" th:text="${section.title}">섹션 제목</p>
                         <p class="text-xs text-gray-400 mt-0.5">
@@ -124,12 +124,60 @@
                     <i class="fa-regular fa-user text-blue-500"></i> 수강생 목록
                 </h3>
                 <span class="px-3 py-1 border border-gray-200 rounded-full text-sm text-gray-600 font-semibold">
-          총 <span th:text="${course.studentCount}">0</span>명
-        </span>
+                    총 <span th:text="${students != null ? #lists.size(students) : 0}">0</span>명
+                </span>
             </div>
-            <div class="text-center text-gray-400 py-16">
+
+            <div th:if="${students == null or #lists.isEmpty(students)}"
+                 class="text-center text-gray-400 py-16">
                 <i class="fa-regular fa-user text-4xl mb-3 block"></i>
-                수강생 상세 정보 기능은 준비 중입니다.
+                아직 수강 중인 학생이 없습니다.
+            </div>
+
+            <div th:if="${students != null and not #lists.isEmpty(students)}" class="space-y-4">
+                <div th:each="student : ${students}"
+                     class="flex items-center justify-between gap-6 p-5 border border-gray-100 rounded-2xl hover:bg-gray-50 transition">
+
+                    <div class="flex items-center gap-4 min-w-0">
+                        <img th:if="${student.profileImg != null and !#strings.isEmpty(student.profileImg)}"
+                             th:src="${student.profileImg}"
+                             alt="student profile"
+                             class="w-14 h-14 rounded-full object-cover border border-gray-200"/>
+
+                        <div th:if="${student.profileImg == null or #strings.isEmpty(student.profileImg)}"
+                             class="w-14 h-14 rounded-full bg-gray-100 border border-gray-200 flex items-center justify-center text-gray-400">
+                            <i class="fa-regular fa-user"></i>
+                        </div>
+
+                        <div class="min-w-0">
+                            <p class="text-base font-black text-gray-900" th:text="${student.name}">홍길동</p>
+                            <p class="text-sm text-gray-500" th:text="${student.nickname}">닉네임</p>
+                            <p class="text-sm text-gray-500 truncate" th:text="${student.email}">email@example.com</p>
+                            <p class="text-xs text-gray-400"
+                               th:text="${student.phone != null ? student.phone : '-'}">010-0000-0000</p>
+                        </div>
+                    </div>
+
+                    <div class="w-64 flex-shrink-0">
+                        <div class="flex items-center justify-between mb-2">
+                            <span class="px-2 py-1 text-xs font-bold rounded-full bg-blue-50 text-blue-600 border border-blue-200"
+                                  th:text="${student.enrollmentStatusLabel}">수강 중</span>
+                            <span class="text-sm font-bold text-gray-700"
+                                  th:text="${student.progressRateLabel}">0%</span>
+                        </div>
+
+                        <div class="h-2 bg-gray-100 rounded-full overflow-hidden">
+                            <div class="h-full bg-blue-500 rounded-full"
+                                 th:style="'width:' + ${student.progressRate} + '%'"></div>
+                        </div>
+
+                        <p class="mt-2 text-xs text-gray-400">
+                            수강 시작일
+                            <span th:text="${student.enrolledDateLabel}">2026-04-21</span>
+                        </p>
+                    </div>
+
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 강사 내 강의 관리 상세 페이지의 `수강생 조회` 탭에 실제 수강생 목록이 보이도록 기능을 추가했습니다.
- 강의별 수강생 정보를 `Enrollment` 기반으로 조회해 강사 본인 강의 상세 화면에서 확인할 수 있도록 했습니다.

## 💡 어떤 기능인가요?
- 강사가 자신이 등록한 강의의 수강생 목록, 수강 상태, 진행률, 수강 시작일을 조회할 수 있는 기능입니다.

## ✨ 변경 사항 (Changes)
- `EnrollmentRepository`
  강의 ID 기준 수강생 목록과 회원 정보를 함께 조회하는 메서드 추가
- `CourseService`
  강사 본인 강의 여부 검증 후 수강생 목록을 조회하는 서비스 로직 추가
- `InstCourseController`
  강의 상세 페이지 진입 시 `students` 데이터를 모델에 함께 전달하도록 수정
- `InstructorCourseStudentResponse`
  수강생 목록 화면 출력을 위한 응답 DTO 추가
- `InstructorCourseDetail.html`
  `수강생 조회` 탭에서 실제 수강생 목록을 렌더링하도록 수정
- **DB 스키마 변경:** 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [ ] JUnit 단위 테스트 (Controller, Service) 통과 확인
- [x] 강사 계정으로 내 강의 관리 상세 페이지 진입 확인
- [x] 수강생이 없는 경우 빈 상태 문구 노출 확인
- [x] 테스트용 `enrollments` 데이터 추가 후 수강생 목록 노출 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 수강생 목록은 `Enrollment` 기준으로 조회하며, 강사 본인 강의인지 먼저 검증하도록 처리했습니다.
- 현재 화면에는 이름, 닉네임, 이메일, 전화번호, 수강 상태, 진행률, 수강 시작일을 노출합니다.
- 진행률은 `enrollments.courses_rate` 값을 그대로 사용합니다.
## ✅ 체크 리스트
- [ ] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #