### PR TITLE
[Feature] 강의 상세 페이지에서 좋아요 등록/취소 기능 구현

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/community/service/LikeService.java
+++ b/src/main/java/com/wanted/naeil/domain/community/service/LikeService.java
@@ -61,7 +61,7 @@ public class LikeService {
                     .targetType(LikeTargetType.COURSE)
                     .course(course)
                     .build());
-            return "/courses/" + course.getId();
+            return "/course/" + course.getId();
         } else {
             throw new IllegalArgumentException("지원하지 않는 좋아요 대상입니다.");
         }
@@ -80,7 +80,7 @@ public class LikeService {
 
         String redirectUrl = like.getTargetType() == LikeTargetType.POST
                 ? "/community/" + like.getPost().getCategory().name().toLowerCase() + "/" + like.getPost().getPostId()
-                : "/courses/" + like.getCourse().getId();
+                : "/course/" + like.getCourse().getId();
 
         likeRepository.delete(like);
         return redirectUrl;

--- a/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
@@ -229,6 +229,6 @@ public class InstCourseController {
     // TODO : 병합 후 강사의 내 강의 페이지로 수정하기
     @GetMapping("/course/complete")
     public String showCompletePage() {
-        return "coursegk/InstructorCourseComplete";
+        return "course/InstructorCourseComplete";
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
@@ -37,7 +37,7 @@ public class InstCourseController {
     private final CategoryRepository  categoryRepository;
 
     // 코스 등록 조회
-    @GetMapping("/course")
+    @GetMapping("/courses")
     public ModelAndView CreateCoursePage(ModelAndView mv,
                                          @AuthenticationPrincipal AuthDetails authDetails) {
         log.info(" [Courses] 강의 생성 페이지 조회 시작");
@@ -47,7 +47,7 @@ public class InstCourseController {
         mv.addObject("createCourseRequest", new CourseCreateRequest());
         mv.addObject("categories", categoryRepository.findAll());
 
-        mv.setViewName("course/courseCreate");
+        mv.setViewName("courses/courseCreate");
 
         return mv;
     }
@@ -59,7 +59,7 @@ public class InstCourseController {
      * @param mv : ModelAndView 호출
      * @return : CreateCoursePage 호출
      */
-    @PostMapping("/course")
+    @PostMapping("/courses")
     public ModelAndView CreateCoursePage(
             @AuthenticationPrincipal AuthDetails authDetails,
             @Valid @ModelAttribute CourseCreateRequest request,
@@ -73,7 +73,7 @@ public class InstCourseController {
             log.warn(" [Validation] 강의 등록 검증 실패: {}", bindingResult.getAllErrors());
 
             mv.addObject("categories", categoryRepository.findAll());
-            mv.setViewName("course/courseCreate");
+            mv.setViewName("courses/courseCreate");
             return mv;
         }
 
@@ -82,12 +82,12 @@ public class InstCourseController {
             mv.addObject("message", response.message());
             // mv.setViewName("redirect:/dashboard/instructorDashboard");
             // 임시페이지
-            mv.setViewName("redirect:/instructor/course/complete");
+            mv.setViewName("redirect:/instructor/courses/complete");
         } catch (Exception e) {
             log.error(" [Courses] 강의 생성 중 오류 발생: ", e);
             mv.addObject("errorMessage", "강의 등록 중 오류가 발생했습니다: " + e.getMessage());
             mv.addObject("categories", categoryRepository.findAll());
-            mv.setViewName("course/courseCreate");
+            mv.setViewName("courses/courseCreate");
         }
 
         return mv;
@@ -109,13 +109,13 @@ public class InstCourseController {
         mv.addObject("courses", courses);
         // TODO : 실시간 강의 등록하면 인자 넣기
         mv.addObject("liveCourses", liveCourses);
-        mv.setViewName("course/InstructorCourseManagement");
+        mv.setViewName("courses/InstructorCourseManagement");
 
         return mv;
     }
 
     // 강의 수정 페이지 조회
-    @GetMapping("/course/{courseId}/edit")
+    @GetMapping("/courses/{courseId}/edit")
     public ModelAndView EditCoursePage(@AuthenticationPrincipal AuthDetails authDetails,
                                        @PathVariable Long courseId,ModelAndView mv) {
 
@@ -126,13 +126,13 @@ public class InstCourseController {
         mv.addObject("user", authDetails.getLoginUserDTO());
         mv.addObject("courseEdit", response);
         mv.addObject("categories", categoryRepository.findAll());
-        mv.setViewName("course/courseEdit");
+        mv.setViewName("courses/courseEdit");
 
         return mv;
     }
 
     // 강의 수정 기능
-    @PatchMapping(value = "/course/{courseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/courses/{courseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseBody
     public ResponseEntity<Void> updateCourse(
             @AuthenticationPrincipal AuthDetails authDetails,
@@ -155,7 +155,7 @@ public class InstCourseController {
      * @param request : 사용자의 입력 상태값
      * @return : ResponseEntity여서 상태만 변경
      */
-    @PatchMapping(value = "/course/{courseId}/status", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/courses/{courseId}/status", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseBody
     public ResponseEntity<Void> updateCourseStatus(
             @AuthenticationPrincipal AuthDetails authDetails,
@@ -179,7 +179,7 @@ public class InstCourseController {
      * @param request : 사용자 입력 상태
      * @return : ResponseEntity여서 상태만 변경
      */
-    @PatchMapping("/course/{courseId}/registration-status")
+    @PatchMapping("/courses/{courseId}/registration-status")
     @ResponseBody
     public ResponseEntity<Void> cancelCourseRegistration(
             @AuthenticationPrincipal AuthDetails authDetails,
@@ -196,7 +196,7 @@ public class InstCourseController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/course/{courseId}/delete-request")
+    @PostMapping("/courses/{courseId}/delete-request")
     public String requestCourseDelete(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long courseId,
@@ -210,7 +210,7 @@ public class InstCourseController {
         return "redirect:/instructor/course-management";
     }
     // 강사 강의 상세 조회
-    @GetMapping("/course/{courseId}/detail")
+    @GetMapping("/courses/{courseId}/detail")
     public ModelAndView courseDetailPage(@PathVariable Long courseId,
                                          ModelAndView mv,
                                          @AuthenticationPrincipal AuthDetails authDetails) {
@@ -218,15 +218,15 @@ public class InstCourseController {
         mv.addObject("user", authDetails.getLoginUserDTO());
         mv.addObject("course", courseService.getInstructorCourseDetail(instructorId, courseId));
         mv.addObject("students", courseService.getInstructorCourseStudents(instructorId, courseId));
-        mv.setViewName("course/InstructorCourseDetail");
+        mv.setViewName("courses/InstructorCourseDetail");
 
         return mv;
     }
 
     // 성공시 redirect 페이지
     // TODO : 병합 후 강사의 내 강의 페이지로 수정하기
-    @GetMapping("/course/complete")
+    @GetMapping("/courses/complete")
     public String showCompletePage() {
-        return "course/InstructorCourseComplete";
+        return "courses/InstructorCourseComplete";
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/course/controller/SectionController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/SectionController.java
@@ -24,7 +24,7 @@ public class SectionController {
     private final SectionService sectionService;
 
     // 섹션 상세 조회 (섹션 수강)
-    @GetMapping("/course/{courseId}/sections/{sectionId}")
+    @GetMapping("/courses/{courseId}/sections/{sectionId}")
     public ModelAndView getSectionStudyPage(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long courseId, @PathVariable Long sectionId,
@@ -36,13 +36,13 @@ public class SectionController {
                 userId, courseId, sectionId);
 
         mv.addObject("sectionStudy", response);
-        mv.setViewName("course/sectionDetail");
+        mv.setViewName("courses/sectionDetail");
 
         return mv;
     }
 
     // 섹션 수정 - 강사
-    @PatchMapping(value = "/instructor/course/{courseId}/sections/{sectionId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/instructor/courses/{courseId}/sections/{sectionId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseBody
     public ResponseEntity<Void> updateSection(
             @AuthenticationPrincipal AuthDetails authDetails,
@@ -60,7 +60,7 @@ public class SectionController {
     }
 
     // 섹션 추가 - 강사
-    @PostMapping("/instructor/course/{courseId}/sections")
+    @PostMapping("/instructor/courses/{courseId}/sections")
     @ResponseBody
     public ResponseEntity<Void> addSection(
             @AuthenticationPrincipal AuthDetails authDetails,
@@ -77,7 +77,7 @@ public class SectionController {
     }
 
     // 섹션 삭제 - 강사
-    @DeleteMapping("/instructor/course/{courseId}/sections/{sectionId}")
+    @DeleteMapping("/instructor/courses/{courseId}/sections/{sectionId}")
     @ResponseBody
     public ResponseEntity<Void> deleteSection(
             @AuthenticationPrincipal AuthDetails authDetails,

--- a/src/main/java/com/wanted/naeil/domain/course/controller/UserCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/UserCourseController.java
@@ -4,6 +4,8 @@ import com.wanted.naeil.domain.course.dto.response.CourseDetailsResponse;
 import com.wanted.naeil.domain.course.dto.response.CourseListResponse;
 import com.wanted.naeil.domain.course.repository.CategoryRepository;
 import com.wanted.naeil.domain.course.service.CourseService;
+import com.wanted.naeil.domain.user.entity.User;
+import com.wanted.naeil.domain.user.repository.UserRepository;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,15 +17,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Controller
-@RequestMapping("/course")
+@RequestMapping("/courses")
 @RequiredArgsConstructor
 @Slf4j
 public class UserCourseController {
 
     private final CourseService courseService;
     private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
 
     @GetMapping
     public ModelAndView showAllCourses(
@@ -53,14 +57,19 @@ public class UserCourseController {
 
         log.info("[Course] 코스 상세 페이지 조회");
 
-        CourseDetailsResponse course = courseService.getCourseDetail(courseId);
+        User loginUser = authDetails != null
+                ? userRepository.findByUsername(authDetails.getLoginUserDTO().getUsername())
+                .orElseThrow(() -> new NoSuchElementException("유저를 찾을 수 없습니다."))
+                : null;
+
+        CourseDetailsResponse course = courseService.getCourseDetail(courseId, loginUser);
 
         if (authDetails != null) {
             mv.addObject("user", authDetails.getLoginUserDTO());
         }
 
         mv.addObject("course", course);
-        mv.setViewName("course/courseDetail");
+        mv.setViewName("courses/courseDetail");
         return mv;
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/course/controller/UserCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/UserCourseController.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 @Controller
-@RequestMapping("/courses")
+@RequestMapping("/course")
 @RequiredArgsConstructor
 @Slf4j
 public class UserCourseController {
@@ -69,7 +69,7 @@ public class UserCourseController {
         }
 
         mv.addObject("course", course);
-        mv.setViewName("courses/courseDetail");
+        mv.setViewName("course/courseDetail");
         return mv;
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/course/dto/response/CourseDetailsResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/course/dto/response/CourseDetailsResponse.java
@@ -25,8 +25,12 @@ public class CourseDetailsResponse {
 
     private List<SectionListResponse> sections;
 
+    private boolean isLiked;
+    private Long likeId;
+
     public static CourseDetailsResponse of(Course course, long likeCount, long studentCount,
-                                           Double avgRating, List<SectionListResponse> sections
+                                           Double avgRating, List<SectionListResponse> sections,
+                                           boolean isLiked, Long likeId
     ) {
         return CourseDetailsResponse.builder()
                 .courseId(course.getId())
@@ -41,6 +45,8 @@ public class CourseDetailsResponse {
                 .sectionCount(sections != null ? sections.size() : 0)
                 .studentCount(studentCount)
                 .sections(sections)
+                .isLiked(isLiked)
+                .likeId(likeId)
                 .build();
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
+++ b/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
@@ -4,6 +4,8 @@ import com.wanted.naeil.domain.admin.entity.AdminApproval;
 import com.wanted.naeil.domain.admin.entity.enums.ApprovalRequestType;
 import com.wanted.naeil.domain.admin.entity.enums.ApprovalStatus;
 import com.wanted.naeil.domain.admin.repository.AdminApprovalRepository;
+import com.wanted.naeil.domain.community.entity.Like;
+import com.wanted.naeil.domain.community.repository.LikeRepository;
 import com.wanted.naeil.domain.course.dto.request.CourseCreateRequest;
 import com.wanted.naeil.domain.course.dto.request.CourseStatusUpdateRequest;
 import com.wanted.naeil.domain.course.dto.request.CourseUpdateRequest;
@@ -33,6 +35,7 @@ import com.wanted.naeil.domain.learning.repository.EnrollmentRepository;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -49,6 +52,7 @@ public class CourseService {
     private final SectionService sectionService;
     private final ModelMapper modelMapper;
     private final EnrollmentRepository enrollmentRepository;
+    private final LikeRepository likeRepository;
 
 
     // 코스 등록 요청 - 강사
@@ -176,7 +180,7 @@ public class CourseService {
 
     // 코스 단일 조회 - 공통
     @Transactional(readOnly = true)
-    public CourseDetailsResponse getCourseDetail(Long courseId) {
+    public CourseDetailsResponse getCourseDetail(Long courseId, User loginUser) {
         
         // 강의,카테고리,강사,섹션 한 번에 조회
         Course course = courseRepository.findCourseDetailsById(courseId)
@@ -189,12 +193,24 @@ public class CourseService {
         // 섹션 리스트 조회
         List<SectionListResponse> sectionsResponses = sectionService.getSectionsByCourseId(courseId);
 
+        // 좋아요 여부 확인
+        boolean isLiked = false;
+        Long likeId = null;
+        if (loginUser != null) {
+            Optional<Like> like = likeRepository.findByUserAndCourse(loginUser, course);
+            if (like.isPresent()) {
+                isLiked = true;
+                likeId = like.get().getLikeId();
+            }
+        }
         return CourseDetailsResponse.of(
                 course,
                 studentCount,
                 likeCount,
                 avgRating,
-                sectionsResponses);
+                sectionsResponses,
+                isLiked,
+                likeId);
     }
 
     // 코스 수정
@@ -366,7 +382,7 @@ public class CourseService {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 강의입니다."));
         validateCourseOwner(course, instructorId);
-        return getCourseDetail(courseId);
+        return getCourseDetail(courseId, null);
     }
     // 강사 강의 상세 페이지 - 해당 강의를 수강 중인 수강생 목록 조회 성민수정
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/course/courseDetail.html
+++ b/src/main/resources/templates/course/courseDetail.html
@@ -107,7 +107,7 @@
 
 <div class="border-b border-gray-200 bg-white">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-    <a th:href="@{/courses}"
+    <a th:href="@{/course}"
        class="inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-blue-600 transition">
       <i class="fa-solid fa-chevron-left text-xs"></i>
       <span>전체 강의로 돌아가기</span>
@@ -255,7 +255,7 @@
             </button>
 
             <div class="hidden bg-gray-50 border-t border-gray-100">
-              <a th:href="@{/courses/{courseId}/sections/{sectionId}(courseId=${course.courseId}, sectionId=${section.sectionId})}"
+              <a th:href="@{/course/{courseId}/sections/{sectionId}(courseId=${course.courseId}, sectionId=${section.sectionId})}"
                  class="px-6 py-4 flex items-center gap-3 hover:bg-gray-100 transition">
                 <i class="fa-solid fa-play text-blue-500 text-xs"></i>
                 <span class="text-sm text-gray-700"

--- a/src/main/resources/templates/course/courseDetail.html
+++ b/src/main/resources/templates/course/courseDetail.html
@@ -107,7 +107,7 @@
 
 <div class="border-b border-gray-200 bg-white">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-    <a th:href="@{/course}"
+    <a th:href="@{/courses}"
        class="inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-blue-600 transition">
       <i class="fa-solid fa-chevron-left text-xs"></i>
       <span>전체 강의로 돌아가기</span>
@@ -156,12 +156,24 @@
           <div class="flex items-center gap-3 shrink-0">
             <span class="font-semibold text-gray-700"
                   th:text="${#numbers.formatInteger(course.likeCount, 0, 'COMMA')}">0</span>
-            <form th:action="@{/likes}" method="post">
+            <!-- 좋아요 안 누른 상태 -->
+            <form th:if="${!course.isLiked}" th:action="@{/likes}" method="post">
               <input type="hidden" name="targetType" value="COURSE">
               <input type="hidden" name="targetId" th:value="${course.courseId}">
               <button type="submit"
                       class="w-9 h-9 rounded-full flex items-center justify-center text-gray-400 hover:text-red-500 hover:bg-red-50 transition">
                 <i class="fa-regular fa-heart"></i>
+              </button>
+            </form>
+
+            <!-- 좋아요 누른 상태 -->
+            <form th:if="${course.isLiked}"
+                  th:action="@{/likes/{likeId}/delete(likeId=${course.likeId})}"
+                  method="post"
+                  onsubmit="return confirm('좋아요를 취소하시겠습니까?')">
+              <button type="submit"
+                      class="w-9 h-9 rounded-full flex items-center justify-center text-red-500 bg-red-50 transition">
+                <i class="fa-solid fa-heart"></i>
               </button>
             </form>
           </div>
@@ -243,7 +255,7 @@
             </button>
 
             <div class="hidden bg-gray-50 border-t border-gray-100">
-              <a th:href="@{/course/{courseId}/sections/{sectionId}(courseId=${course.courseId}, sectionId=${section.sectionId})}"
+              <a th:href="@{/courses/{courseId}/sections/{sectionId}(courseId=${course.courseId}, sectionId=${section.sectionId})}"
                  class="px-6 py-4 flex items-center gap-3 hover:bg-gray-100 transition">
                 <i class="fa-solid fa-play text-blue-500 text-xs"></i>
                 <span class="text-sm text-gray-700"


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 강의 상세 페이지에서 좋아요 등록/취소 기능 연동
- `CourseDetailsResponse`에 `isLiked`, `likeId` 필드 추가
- 좋아요 상태에 따라 버튼 분기 처리

## 💡 어떤 기능인가요?
- 강의 상세 페이지에서 로그인한 유저가 좋아요를 등록하거나 취소할 수 있어요.
- 이미 좋아요를 누른 상태면 취소 확인 다이얼로그가 뜨고, 누르지 않은 상태면 바로 등록돼요.
- 좋아요 등록/취소 후 현재 강의 상세 페이지로 redirect돼요.

## ✨ 변경 사항 (Changes)
- `CourseDetailsResponse` - `isLiked`(boolean), `likeId`(Long) 필드 추가, `of()` 메서드 파라미터 추가
- `CourseService.getCourseDetail()` - `User loginUser` 파라미터 추가, `LikeRepository`로 좋아요 여부 조회
- `CourseService.getInstructorCourseDetail()` - `getCourseDetail()` 호출 시 `loginUser = null`로 처리
- `UserCourseController.getCourseDetails()` - `loginUser` 조회 후 Service에 전달, `UserRepository` 주입
- `courseDetail.html` - 좋아요 버튼 `isLiked` 분기 처리 (등록/취소 버튼 전환)
- **DB 스키마 변경:** 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 로컬 환경 브라우저를 통한 강의 좋아요 등록 및 DB 반영 확인
- [x] 로컬 환경 브라우저를 통한 강의 좋아요 취소 및 DB 반영 확인
- [x] 좋아요 누른 상태/안 누른 상태 버튼 분기 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- `CourseService.getCourseDetail()`에 `User loginUser` 파라미터가 추가됐어요. 해당 메서드를 호출하는 곳이 있다면 확인 부탁드려요.
- 비로그인 상태에서는 `loginUser = null`로 처리하여 `isLiked = false`, `likeId = null`로 반환해요.

## ✅ 체크 리스트
- [x] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
- Closes #213 