### PR TITLE
Feature ajs 수강 중단/수강 완료 처리 및 학습 완료 시 다음 섹션 자동 이동 구현

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/InstCourseController.java
@@ -17,6 +17,7 @@ import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
@@ -30,6 +31,7 @@ import java.util.List;
 @RequestMapping("/instructor")
 @RequiredArgsConstructor
 @Slf4j
+@PreAuthorize("hasAnyAuthority('ADMIN', 'INSTRUCTOR')")
 public class InstCourseController {
 
     private final CourseService courseService;
@@ -215,6 +217,7 @@ public class InstCourseController {
                                          @RequestParam(defaultValue = "lecture") String tab,
                                          ModelAndView mv,
                                          @AuthenticationPrincipal AuthDetails authDetails) {
+
         Long instructorId = authDetails.getLoginUserDTO().getUserId();
         mv.addObject("user", authDetails.getLoginUserDTO());
         mv.addObject("course", courseService.getInstructorCourseDetail(instructorId, courseId));

--- a/src/main/java/com/wanted/naeil/domain/course/controller/SectionController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/SectionController.java
@@ -37,7 +37,7 @@ public class SectionController {
                 userId, courseId, sectionId);
 
         mv.addObject("sectionStudy", response);
-        mv.setViewName("courses/sectionDetail");
+        mv.setViewName("course/sectionDetail");
 
         return mv;
     }
@@ -97,4 +97,37 @@ public class SectionController {
 
         return ResponseEntity.ok().build();
     }
+
+    // 학습 중단
+    @PostMapping("/courses/{courseId}/sections/{sectionId}/stop")
+    public String stopLearning(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long courseId,
+            @PathVariable Long sectionId
+    ) {
+        Long userId = authDetails.getLoginUserDTO().getUserId();
+
+        sectionService.stopLearning(userId, courseId, sectionId);
+
+        return "redirect:/my-courses";
+    }
+
+    // 학습 완료
+    @PostMapping("/courses/{courseId}/sections/{sectionId}/complete")
+    public String completeLearning(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long courseId,
+            @PathVariable Long sectionId
+    ) {
+        Long userId = authDetails.getLoginUserDTO().getUserId();
+
+        Long nextSectionId = sectionService.completeLearning(userId, courseId, sectionId);
+
+        if (nextSectionId != null) {
+            return "redirect:/courses/" + courseId + "/sections/" + nextSectionId;
+        }
+
+        return "redirect:/my-courses";
+    }
+
 }

--- a/src/main/java/com/wanted/naeil/domain/course/controller/SectionController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/SectionController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -44,6 +45,7 @@ public class SectionController {
     // 섹션 수정 - 강사
     @PatchMapping(value = "/instructor/courses/{courseId}/sections/{sectionId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseBody
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'INSTRUCTOR')")
     public ResponseEntity<Void> updateSection(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long courseId,
@@ -62,6 +64,7 @@ public class SectionController {
     // 섹션 추가 - 강사
     @PostMapping("/instructor/courses/{courseId}/sections")
     @ResponseBody
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'INSTRUCTOR')")
     public ResponseEntity<Void> addSection(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long courseId,
@@ -79,6 +82,7 @@ public class SectionController {
     // 섹션 삭제 - 강사
     @DeleteMapping("/instructor/courses/{courseId}/sections/{sectionId}")
     @ResponseBody
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'INSTRUCTOR')")
     public ResponseEntity<Void> deleteSection(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long courseId,

--- a/src/main/java/com/wanted/naeil/domain/course/dto/response/CourseDetailsResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/course/dto/response/CourseDetailsResponse.java
@@ -22,6 +22,7 @@ public class CourseDetailsResponse {
     private final long likeCount;
     private final long sectionCount;
     private final long studentCount;
+    private final boolean enrolled;
 
     private List<SectionListResponse> sections;
 
@@ -30,7 +31,7 @@ public class CourseDetailsResponse {
 
     public static CourseDetailsResponse of(Course course, long likeCount, long studentCount,
                                            Double avgRating, List<SectionListResponse> sections,
-                                           boolean isLiked, Long likeId
+                                           boolean isLiked, Long likeId, boolean enrolled
     ) {
         return CourseDetailsResponse.builder()
                 .courseId(course.getId())
@@ -47,6 +48,7 @@ public class CourseDetailsResponse {
                 .sections(sections)
                 .isLiked(isLiked)
                 .likeId(likeId)
+                .enrolled(enrolled)
                 .build();
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/course/repository/SectionRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/course/repository/SectionRepository.java
@@ -4,6 +4,7 @@ import com.wanted.naeil.domain.course.dto.CurriculumSectionDTO;
 import com.wanted.naeil.domain.course.dto.SectionStudyMainDTO;
 import com.wanted.naeil.domain.course.entity.Course;
 import com.wanted.naeil.domain.course.entity.Section;
+import com.wanted.naeil.domain.course.entity.enums.SectionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -59,4 +60,33 @@ public interface SectionRepository extends JpaRepository<Section, Long> {
     );
 
     int countByCourseId(Long courseId);
+
+    // 섹션 개수 조회
+    int countByCourseIdAndStatus(Long courseId, SectionStatus status);
+
+    // 첫 번째 활성 섹션 조회 추가
+    Optional<Section> findFirstByCourseIdAndStatusOrderBySequenceAsc(
+            Long courseId,
+            SectionStatus status
+    );
+
+    // 다음 섹션 찾기
+    @Query("""
+    select nextSection.id
+    from Section nextSection
+    where nextSection.course.id = :courseId
+      and nextSection.status = com.wanted.naeil.domain.course.entity.enums.SectionStatus.ACTIVE
+      and nextSection.sequence > (
+          select currentSection.sequence
+          from Section currentSection
+          where currentSection.id = :sectionId
+      )
+    order by nextSection.sequence asc
+    """)
+    List<Long> findNextActiveSectionIds(
+            @Param("courseId") Long courseId,
+            @Param("sectionId") Long sectionId
+    );
+
+
 }

--- a/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
+++ b/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
@@ -198,6 +198,11 @@ public class CourseService {
         // 섹션 리스트 조회
         List<SectionListResponse> sectionsResponses = sectionService.getSectionsByCourseId(courseId);
 
+        boolean enrolled = false;
+
+        if (loginUser != null) {
+            enrolled = enrollmentRepository.existsByUserIdAndCourseId(loginUser.getId(), courseId);
+        }
         // 좋아요 여부 확인
         boolean isLiked = false;
         Long likeId = null;
@@ -215,7 +220,8 @@ public class CourseService {
                 avgRating,
                 sectionsResponses,
                 isLiked,
-                likeId);
+                likeId,
+                enrolled);
     }
 
     // 코스 수정

--- a/src/main/java/com/wanted/naeil/domain/course/service/SectionService.java
+++ b/src/main/java/com/wanted/naeil/domain/course/service/SectionService.java
@@ -12,9 +12,14 @@ import com.wanted.naeil.domain.course.entity.Section;
 import com.wanted.naeil.domain.course.entity.enums.SectionStatus;
 import com.wanted.naeil.domain.course.repository.CourseRepository;
 import com.wanted.naeil.domain.course.repository.SectionRepository;
+import com.wanted.naeil.domain.learning.entity.Enrollment;
+import com.wanted.naeil.domain.learning.entity.LearningProgress;
 import com.wanted.naeil.domain.learning.entity.enums.EnrollmentStatus;
 import com.wanted.naeil.domain.learning.entity.enums.ProgressStatus;
 import com.wanted.naeil.domain.learning.repository.EnrollmentRepository;
+import com.wanted.naeil.domain.learning.repository.LearningProgressRepository;
+import com.wanted.naeil.domain.user.entity.User;
+import com.wanted.naeil.domain.user.repository.UserRepository;
 import com.wanted.naeil.global.util.file.FileTransactionService;
 import com.wanted.naeil.global.util.file.LocalFileService;
 import jakarta.validation.Valid;
@@ -43,6 +48,8 @@ public class SectionService {
     private final LocalFileService localFileService;
     private final FileTransactionService fileTransactionService;
     private final EnrollmentRepository enrollmentRepository;
+    private final LearningProgressRepository learningProgressRepository;
+    private final UserRepository userRepository;
     // 시간 포멧팅
     private static final DateTimeFormatter PLAY_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
@@ -291,7 +298,7 @@ public class SectionService {
                 instructorId, courseId, sectionId);
     }
 
-    // 섹션 삭제
+    // 섹션 삭제 - 강사
     @Transactional
     public void deleteSection(Long instructorId, Long courseId, Long sectionId) {
 
@@ -308,8 +315,80 @@ public class SectionService {
                 instructorId, courseId, sectionId);
     }
 
+    // 학습 중단
+    @Transactional
+    public void stopLearning(Long userId, Long courseId, Long sectionId) {
+        validateEnrolled(userId, courseId);
+
+        LearningProgress progress = getOrCreateProgress(userId, sectionId);
+        progress.stop();
+
+        updateCourseProgress(userId, courseId);
+    }
+
+    // 학습 완료
+    @Transactional
+    public Long completeLearning(Long userId, Long courseId, Long sectionId) {
+        validateEnrolled(userId, courseId);
+
+        LearningProgress progress = getOrCreateProgress(userId, sectionId);
+        progress.complete();
+
+        updateCourseProgress(userId, courseId);
+
+        return sectionRepository.findNextActiveSectionIds(courseId, sectionId)
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
+
 
     // ============= 내부 편의 메서드 ================
+
+    private void validateEnrolled(Long userId, Long courseId) {
+        enrollmentRepository.findByUserIdAndCourseId(userId, courseId)
+                .orElseThrow(() -> new AccessDeniedException("수강 중인 강의가 아닙니다."));
+    }
+
+    private LearningProgress getOrCreateProgress(Long userId, Long sectionId) {
+        return learningProgressRepository.findByUserIdAndSectionId(userId, sectionId)
+                .orElseGet(() -> {
+                    User user = userRepository.findById(userId)
+                            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 사용자입니다."));
+
+                    Section section = sectionRepository.findById(sectionId)
+                            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 섹션입니다."));
+
+                    return learningProgressRepository.save(
+                            LearningProgress.builder()
+                                    .user(user)
+                                    .section(section)
+                                    .build()
+                    );
+                });
+    }
+
+    private void updateCourseProgress(Long userId, Long courseId) {
+        Enrollment enrollment = enrollmentRepository.findByUserIdAndCourseId(userId, courseId)
+                .orElseThrow(() -> new AccessDeniedException("수강 중인 강의가 아닙니다."));
+
+        int totalCount = sectionRepository.countByCourseIdAndStatus(courseId, SectionStatus.ACTIVE);
+
+        long completedCount = learningProgressRepository.findByUserIdAndSectionCourseId(userId, courseId)
+                .stream()
+                .filter(progress -> progress.getStatus() == ProgressStatus.COMPLETED)
+                .count();
+
+        double rate = totalCount == 0 ? 0 : completedCount * 100.0 / totalCount;
+
+        enrollment.updateProgress(rate);
+
+        if (rate >= 100.0) {
+            enrollment.updateStatus(EnrollmentStatus.COMPLETED);
+        } else if (rate > 0) {
+            enrollment.updateStatus(EnrollmentStatus.IN_PROGRESS);
+        }
+    }
 
     private String formatPlayTime(LocalTime playTime) {
         return playTime != null

--- a/src/main/java/com/wanted/naeil/domain/learning/dto/response/MyCourseResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/dto/response/MyCourseResponse.java
@@ -1,5 +1,6 @@
 package com.wanted.naeil.domain.learning.dto.response;
 
+import com.wanted.naeil.domain.learning.entity.enums.EnrollmentStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,4 +21,7 @@ public class MyCourseResponse {
     private Long reviewId;
     private Double rating;
     private String reviewContent;
+
+    private EnrollmentStatus enrollmentStatus;
+    private Long firstSectionId;
 }

--- a/src/main/java/com/wanted/naeil/domain/learning/repository/EnrollmentRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/repository/EnrollmentRepository.java
@@ -1,6 +1,7 @@
 package com.wanted.naeil.domain.learning.repository;
 
 import com.wanted.naeil.domain.learning.entity.Enrollment;
+import com.wanted.naeil.domain.learning.entity.LearningProgress;
 import com.wanted.naeil.domain.learning.entity.enums.EnrollmentStatus;
 import com.wanted.naeil.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -47,4 +48,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     List<Enrollment> findAllWithUserByCourseIdOrderByCreatedAtDesc(
             @Param("courseId") Long courseId
     );
+
+    // 수강 정보 조회
+    Optional<Enrollment> findByUserIdAndCourseId(Long userId, Long courseId);
 }

--- a/src/main/java/com/wanted/naeil/domain/learning/repository/LearningProgressRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/repository/LearningProgressRepository.java
@@ -1,0 +1,14 @@
+package com.wanted.naeil.domain.learning.repository;
+
+import com.wanted.naeil.domain.learning.entity.LearningProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LearningProgressRepository extends JpaRepository<LearningProgress, Long> {
+
+    Optional<LearningProgress> findByUserIdAndSectionId(Long userId, Long sectionId);
+
+    List<LearningProgress> findByUserIdAndSectionCourseId(Long userId, Long courseId);
+}

--- a/src/main/java/com/wanted/naeil/domain/learning/service/MyCourseService.java
+++ b/src/main/java/com/wanted/naeil/domain/learning/service/MyCourseService.java
@@ -1,5 +1,7 @@
 package com.wanted.naeil.domain.learning.service;
 
+import com.wanted.naeil.domain.course.entity.enums.SectionStatus;
+import com.wanted.naeil.domain.course.repository.SectionRepository;
 import com.wanted.naeil.domain.learning.dto.response.MyCourseResponse;
 import com.wanted.naeil.domain.course.entity.Review;
 import com.wanted.naeil.domain.course.repository.ReviewRepository;
@@ -26,6 +28,7 @@ public class MyCourseService {
     private final EnrollmentRepository enrollmentRepository;
     private final ReviewRepository reviewRepository;
     private final LiveReservationRepository liveReservationRepository;
+    private final SectionRepository sectionRepository;
 
     // 내 강의 목록 조회
     @Transactional(readOnly = true)
@@ -38,12 +41,22 @@ public class MyCourseService {
                             loginUser,
                             enrollment.getCourse()
                     );
+                    Long firstSectionId = sectionRepository
+                            .findFirstByCourseIdAndStatusOrderBySequenceAsc(
+                                    enrollment.getCourse().getId(),
+                                    SectionStatus.ACTIVE
+                            )
+                            .map(section -> section.getId())
+                            .orElse(null);
+
                     return MyCourseResponse.builder()
                             .courseId(enrollment.getCourse().getId())
                             .thumbnail(enrollment.getCourse().getThumbnail())
                             .title(enrollment.getCourse().getTitle())
                             .instructorName(enrollment.getCourse().getInstructor().getName())
                             .coursesRate(enrollment.getCoursesRate())
+                            .enrollmentStatus(enrollment.getStatus())
+                            .firstSectionId(firstSectionId)
                             .reviewId(review.map(Review::getId).orElse(null))
                             .rating(review.map(Review::getRating).orElse(null))
                             .reviewContent(review.map(Review::getContent).orElse(null))

--- a/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
+++ b/src/main/java/com/wanted/naeil/domain/live/controller/InstLiveController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
@@ -24,6 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/instructor")
 @Slf4j
+@PreAuthorize("hasAnyAuthority('ADMIN', 'INSTRUCTOR')")
 public class InstLiveController {
 
     private final LiveLectureService liveLectureService;
@@ -39,10 +41,6 @@ public class InstLiveController {
             @AuthenticationPrincipal AuthDetails authDetails,
             ModelAndView mv
             ) {
-        // 로그인 검증
-        if (authDetails == null) {
-            throw new AccessDeniedException("로그인이 필요합니다.");
-        }
 
         Role userRole = authDetails.getLoginUserDTO().getRole();
 
@@ -77,10 +75,6 @@ public class InstLiveController {
             ModelAndView mv,
             RedirectAttributes redirectAttributes
     ) {
-
-        if (authDetails == null) {
-            throw new AccessDeniedException("로그인이 필요합니다.");
-        }
 
         Long instructorId = authDetails.getLoginUserDTO().getUserId();
 
@@ -125,10 +119,6 @@ public class InstLiveController {
             @PathVariable Long liveId,
             ModelAndView mv
     ) {
-        if (authDetails == null) {
-            throw new AccessDeniedException("로그인이 필요합니다.");
-        }
-
         Long instructorId = authDetails.getLoginUserDTO().getUserId();
 
         InstructorLiveDetailResponse response =
@@ -156,9 +146,6 @@ public class InstLiveController {
             @PathVariable Long liveId,
             ModelAndView mv
     ) {
-        if (authDetails == null) {
-            throw new AccessDeniedException("로그인이 필요합니다.");
-        }
 
         Long instructorId = authDetails.getLoginUserDTO().getUserId();
 
@@ -185,9 +172,6 @@ public class InstLiveController {
             @PathVariable Long liveId,
             @Valid @ModelAttribute CreateLiveLectureRequest request
     ) {
-        if (authDetails == null) {
-            throw new AccessDeniedException("로그인이 필요합니다.");
-        }
 
         Long instructorId = authDetails.getLoginUserDTO().getUserId();
 
@@ -206,14 +190,17 @@ public class InstLiveController {
         }
     }
 
+    /**
+     * 라이브 강의 삭제 기능
+     * @param authDetails
+     * @param liveId : 삭제할 실시간 강의 번호
+     * @return
+     */
     @DeleteMapping("/live-lecture/{liveId}")
     public ResponseEntity<String> deleteInstructorLiveLecture(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long liveId
     ) {
-        if (authDetails == null) {
-            throw new AccessDeniedException("로그인이 필요합니다.");
-        }
 
         Long instructorId = authDetails.getLoginUserDTO().getUserId();
 
@@ -239,9 +226,6 @@ public class InstLiveController {
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long liveId
     ) {
-        if (authDetails == null) {
-            throw new AccessDeniedException("로그인 후 예약자 목록을 조회할 수 있습니다.");
-        }
 
         Long instructorId = authDetails.getLoginUserDTO().getUserId();
 

--- a/src/main/java/com/wanted/naeil/domain/settlement/controller/SettlementController.java
+++ b/src/main/java/com/wanted/naeil/domain/settlement/controller/SettlementController.java
@@ -5,6 +5,7 @@ import com.wanted.naeil.domain.settlement.entity.enums.SettlementStatus;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
 import com.wanted.naeil.domain.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,6 +17,7 @@ import java.util.List;
 @Controller
 @RequestMapping("/instructor/settlements")
 @RequiredArgsConstructor
+@PreAuthorize("hasAnyAuthority('ADMIN', 'INSTRUCTOR')")
 public class SettlementController {
 
     private final SettlementService settlementService;

--- a/src/main/resources/templates/course/courseDetail.html
+++ b/src/main/resources/templates/course/courseDetail.html
@@ -223,35 +223,55 @@
 
         <div class="divide-y divide-gray-200">
           <div th:each="section, stat : ${course.sections}">
-            <button type="button"
-                    class="w-full px-6 py-5 flex items-center justify-between text-left hover:bg-gray-50 transition"
-                    onclick="this.nextElementSibling.classList.toggle('hidden')">
+
+            <!-- 미리보기 섹션: 누구나 펼치기 가능 -->
+            <div th:if="${section.isFree}">
+              <button type="button"
+                      class="w-full px-6 py-5 flex items-center justify-between text-left hover:bg-gray-50 transition"
+                      onclick="this.nextElementSibling.classList.toggle('hidden')">
+                <div class="min-w-0 pr-4">
+                  <p class="font-bold text-gray-900 break-words"
+                     th:text="|섹션 ${stat.count}. ${section.title}|">섹션명</p>
+                </div>
+
+                <div class="flex items-center gap-3 shrink-0">
+          <span class="text-[11px] font-bold text-green-700 bg-green-100 px-2 py-1 rounded-md">
+            미리보기
+          </span>
+                  <span class="text-sm text-gray-500 font-medium"
+                        th:text="${section.playTime}">00:15</span>
+                  <i class="fa-solid fa-chevron-down text-sm text-gray-400"></i>
+                </div>
+              </button>
+
+              <div class="hidden bg-gray-50 border-t border-gray-100">
+                <a th:href="@{/courses/{courseId}/sections/{sectionId}(courseId=${course.courseId}, sectionId=${section.sectionId})}"
+                   class="px-6 py-4 flex items-center gap-3 hover:bg-gray-100 transition">
+                  <i class="fa-solid fa-play text-blue-500 text-xs"></i>
+                  <span class="text-sm text-gray-700"
+                        th:text="${section.title} + ' 미리보기'">미리보기</span>
+                </a>
+              </div>
+            </div>
+
+            <!-- 일반 섹션: 제목만 표시, 펼치기/링크 없음 -->
+            <div th:unless="${section.isFree}"
+                 class="w-full px-6 py-5 flex items-center justify-between text-left bg-white">
               <div class="min-w-0 pr-4">
                 <p class="font-bold text-gray-900 break-words"
                    th:text="|섹션 ${stat.count}. ${section.title}|">섹션명</p>
               </div>
 
               <div class="flex items-center gap-3 shrink-0">
-                <span th:if="${section.isFree}"
-                      class="text-[11px] font-bold text-green-700 bg-green-100 px-2 py-1 rounded-md">
-                  무료공개
-                </span>
-                <span class="text-sm text-gray-500 font-medium"
-                      th:text="${section.playTime}">00:15</span>
-                <i class="fa-solid fa-chevron-down text-sm text-gray-400"></i>
+        <span class="text-sm text-gray-500 font-medium"
+              th:text="${section.playTime}">00:15</span>
+                <i class="fa-solid fa-lock text-sm text-gray-400"></i>
               </div>
-            </button>
-
-            <div class="hidden bg-gray-50 border-t border-gray-100">
-              <a th:href="@{/course/{courseId}/sections/{sectionId}(courseId=${course.courseId}, sectionId=${section.sectionId})}"
-                 class="px-6 py-4 flex items-center gap-3 hover:bg-gray-100 transition">
-                <i class="fa-solid fa-play text-blue-500 text-xs"></i>
-                <span class="text-sm text-gray-700"
-                      th:text="${section.title} + ' 학습하기'">강의명</span>
-              </a>
             </div>
+
           </div>
         </div>
+
       </div>
 
       <!-- Reviews placeholder -->
@@ -272,23 +292,45 @@
           </div>
 
           <div class="space-y-3">
-            <!-- 바로 결제 -->
-            <form th:action="@{/payments/courses/direct/{courseId}(courseId=${course.courseId})}" method="post">
-              <button type="submit"
-                      class="w-full h-14 rounded-2xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-lg flex items-center justify-center gap-2 transition">
-                <i class="fa-regular fa-credit-card"></i>
-                <span>바로 결제</span>
-              </button>
-            </form>
 
-            <!-- 장바구니 담기 -->
-            <form th:action="@{/cart/add/{courseId}(courseId=${course.courseId})}" method="post">
-              <button type="submit"
-                      class="w-full h-14 rounded-2xl border border-gray-300 bg-white hover:bg-gray-50 text-gray-900 font-bold text-lg flex items-center justify-center gap-2 transition">
-                <i class="fa-solid fa-cart-shopping"></i>
-                <span>장바구니 담기</span>
+            <!-- 구매한 사용자: 수강하기 버튼만 표시 -->
+            <div th:if="${course.enrolled}">
+              <a th:if="${course.enrolled}"
+                 th:href="@{/my-courses}"
+                 class="w-full h-14 rounded-2xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-lg flex items-center justify-center gap-2 transition">
+                <i class="fa-solid fa-play"></i>
+                <span>수강 하기</span>
+              </a>
+
+
+              <button th:if="${course.sectionCount == 0}"
+                      type="button"
+                      disabled
+                      class="w-full h-14 rounded-2xl bg-gray-300 text-white font-bold text-lg flex items-center justify-center gap-2 cursor-not-allowed">
+                <i class="fa-solid fa-play"></i>
+                <span>등록된 강의가 없습니다</span>
               </button>
-            </form>
+            </div>
+
+            <!-- 구매하지 않은 사용자: 결제 / 장바구니 표시 -->
+            <div th:unless="${course.enrolled}" class="space-y-3">
+              <form th:action="@{/payments/courses/direct/{courseId}(courseId=${course.courseId})}" method="post">
+                <button type="submit"
+                        class="w-full h-14 rounded-2xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-lg flex items-center justify-center gap-2 transition">
+                  <i class="fa-regular fa-credit-card"></i>
+                  <span>바로 결제</span>
+                </button>
+              </form>
+
+              <form th:action="@{/cart/add/{courseId}(courseId=${course.courseId})}" method="post">
+                <button type="submit"
+                        class="w-full h-14 rounded-2xl border border-gray-300 bg-white hover:bg-gray-50 text-gray-900 font-bold text-lg flex items-center justify-center gap-2 transition">
+                  <i class="fa-solid fa-cart-shopping"></i>
+                  <span>장바구니 담기</span>
+                </button>
+              </form>
+            </div>
+
           </div>
 
           <div class="mt-6 pt-6 border-t border-gray-200 space-y-3">

--- a/src/main/resources/templates/course/sectionDetail.html
+++ b/src/main/resources/templates/course/sectionDetail.html
@@ -97,21 +97,28 @@
           </div>
         </section>
 
-        <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <button type="button"
-                    class="h-12 rounded-lg border border-slate-300 bg-white text-sm font-extrabold text-slate-700 hover:bg-slate-50">
-              <i class="fa-solid fa-pause mr-2 text-xs"></i>
-              학습 중단
-            </button>
+        <form th:action="@{/courses/{courseId}/sections/{sectionId}/stop(
+        courseId=${sectionStudy.course.courseId},
+        sectionId=${sectionStudy.video.sectionId})}"
+              method="post">
+          <button type="submit"
+                  class="h-12 w-full rounded-lg border border-slate-300 bg-white text-sm font-extrabold text-slate-700 hover:bg-slate-50">
+            <i class="fa-solid fa-pause mr-2 text-xs"></i>
+            학습 중단
+          </button>
+        </form>
 
-            <button type="button"
-                    class="h-12 rounded-lg border border-slate-300 bg-white text-sm font-extrabold text-slate-700 hover:bg-slate-50">
-              <i class="fa-regular fa-circle-check mr-2 text-xs"></i>
-              학습 완료
-            </button>
-          </div>
-        </section>
+        <form th:action="@{/courses/{courseId}/sections/{sectionId}/complete(
+        courseId=${sectionStudy.course.courseId},
+        sectionId=${sectionStudy.video.sectionId})}"
+              method="post">
+          <button type="submit"
+                  class="h-12 w-full rounded-lg border border-slate-300 bg-white text-sm font-extrabold text-slate-700 hover:bg-slate-50">
+            <i class="fa-regular fa-circle-check mr-2 text-xs"></i>
+            학습 완료
+          </button>
+        </form>
+
 
         <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
           <div class="flex items-start justify-between gap-4 border-b border-slate-100 pb-5">
@@ -215,7 +222,7 @@
 
           <div class="divide-y divide-slate-100 border-t border-slate-200">
             <a th:each="item, stat : ${sectionStudy.curriculum.sections}"
-               th:href="@{/course/{courseId}/sections/{sectionId}(courseId=${sectionStudy.course.courseId}, sectionId=${item.sectionId})}"
+               th:href="@{/courses/{courseId}/sections/{sectionId}(courseId=${sectionStudy.course.courseId}, sectionId=${item.sectionId})}"
                th:class="${item.current} ? 'flex gap-3 bg-blue-50 px-5 py-4' : 'flex gap-3 px-5 py-4 hover:bg-slate-50'">
 
               <i th:if="${item.current}"

--- a/src/main/resources/templates/my-courses/myCourses.html
+++ b/src/main/resources/templates/my-courses/myCourses.html
@@ -57,8 +57,11 @@
        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
     <div th:each="course : ${myCourses}"
          class="bg-white border-2 border-gray-200 rounded-2xl p-6 hover:shadow-xl transition-all">
-      <a th:href="@{/course/{id}(id=${course.courseId})}" class="block group">
-        <div class="aspect-video bg-gray-100 rounded-xl mb-4 overflow-hidden">
+      <a th:href="${course.firstSectionId != null}
+        ? @{/courses/{courseId}/sections/{sectionId}(courseId=${course.courseId}, sectionId=${course.firstSectionId})}
+        : @{/course/{id}(id=${course.courseId})}"
+         class="block group">
+      <div class="aspect-video bg-gray-100 rounded-xl mb-4 overflow-hidden">
           <img th:src="${course.thumbnail}" th:alt="${course.title}" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"/>
         </div>
         <h3 class="text-lg font-bold text-gray-900 mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors" th:text="${course.title}">강의 제목</h3>
@@ -75,7 +78,10 @@
         <div class="mb-4">
           <div class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-gradient-to-r from-blue-600 to-green-600 text-white rounded-xl font-bold">
             <i class="fa-solid fa-play text-sm"></i>
-            <span>이어보기</span>
+            <span th:text="${course.enrollmentStatus != null and course.enrollmentStatus.name() == 'BEFORE_START'} ? '수강 하기' :
+               (${course.enrollmentStatus != null and course.enrollmentStatus.name() == 'COMPLETED'} ? '복습하기' : '이어보기')">
+              수강 하기
+            </span>
           </div>
         </div>
       </a>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- #Ref #230 
- 

## 💡 어떤 기능인가요?
- 사용자가 학습을 중단 ->학습 중 상태로 기록하고 내 강의 페이지로 이동한다.
- 사용자가 학습을 완료하면 현재 섹션을 완료 처리하고, 다음 섹션이 있으면 바로 다음 섹션 수강 페이지로 이동
- 마지막 섹션까지 완료한 경우에는 내 강의 페이지로 이동하며, 수강률이 100%가 된 강의는 내 강의 페이지에서 복습하기로 표시한다.

## ✨ 변경 사항 (Changes)
- 기존 첫 수강이여도 버튼이 이어하기 였는데, 상태에 따라 분기

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] JUnit 단위 테스트 (Controller, Service) 통과 확인
- [x] Postman을 통한 로컬 환경 API 엔드포인트 응답 테스트 완료

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말

## ✅ 체크 리스트
- [ ] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [ ] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [ ] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #