### PR TITLE
블랙리스트 등록 회원 로그인 시도시 문구변경

### DIFF
--- a/src/main/java/com/wanted/naeil/global/auth/handler/AuthFailureHandler.java
+++ b/src/main/java/com/wanted/naeil/global/auth/handler/AuthFailureHandler.java
@@ -1,0 +1,22 @@
+package com.wanted.naeil.global.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import java.io.IOException;
+
+public class AuthFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        if (exception instanceof LockedException) {
+            response.sendRedirect("/auth/login?blacklist=true");
+        } else {
+            response.sendRedirect("/auth/login?error=true");
+        }
+    }
+}

--- a/src/main/java/com/wanted/naeil/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/naeil/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.wanted.naeil.global.config;
 
+import com.wanted.naeil.global.auth.handler.AuthFailureHandler;
 import com.wanted.naeil.global.auth.handler.AuthSuccessHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,9 +38,15 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthFailureHandler authFailureHandler() {
+        return new AuthFailureHandler();
+    }
+
+    @Bean
     public SecurityFilterChain configure(HttpSecurity http,
                                          SessionRegistry sessionRegistry,
-                                         AuthSuccessHandler authSuccessHandler) throws Exception {
+                                         AuthSuccessHandler authSuccessHandler,
+                                         AuthFailureHandler authFailureHandler) throws Exception {
 
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers("/auth/login", "/auth/signup", "/auth/fail", "/auth/find-id", "/auth/find-password",  "/", "/dashboard", "/dashboard/guest", "/course/**","/subscription/**",  "/community/**", "/error").permitAll();
@@ -60,7 +67,7 @@ public class SecurityConfig {
                     login.loginPage("/auth/login");
                     login.usernameParameter("user");
                     login.passwordParameter("pass");
-                    login.failureUrl("/auth/login?error=true");
+                    login.failureHandler(authFailureHandler);
                     login.successHandler(authSuccessHandler); // defaultSuccessUrl 대신
                 }).rememberMe(rememberMe -> {
                     rememberMe.rememberMeParameter("remember-me");

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -37,6 +37,11 @@
         <p class="text-sm font-bold text-red-600">아이디 또는 비밀번호가 올바르지 않습니다.</p>
     </div>
 
+    <!-- 블랙리스트 메시지 -->
+    <div th:if="${param.blacklist}" class="mb-4 p-4 bg-red-50 border-2 border-red-200 rounded-xl">
+        <p class="text-sm font-bold text-red-600">블랙리스트 유저입니다. 관리자에게 문의해주세요.</p>
+    </div>
+
     <!-- 비밀번호 변경 성공 메시지 -->
     <div th:if="${message}" class="mb-4 p-4 bg-green-50 border-2 border-green-200 rounded-xl">
         <p class="text-sm font-bold text-green-600" th:text="${message}"></p>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
블랙리스트 유저 로그인 시도 시 전용 안내 메시지 표시 기능 추가
- 

## 💡 어떤 기능인가요?
BANNED 상태 유저가 로그인 시도할 때 "아이디 또는 비밀번호가 올바르지 않습니다" 대신 "블랙리스트 유저입니다. 관리자에게 문의해주세요."를 표시
-
## ✨ 변경 사항 (Changes)
-AuthFailureHandler 추가: 로그인 실패 예외 타입에 따라 리다이렉트 분기 처리
-SecurityConfig 수정: failureUrl 대신 AuthFailureHandler 등록
-login.html 수정: blacklist 파라미터 감지 시 블랙리스트 전용 에러 메시지 렌더링
-DB 스키마 변경: 없음

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] JUnit 단위 테스트 (Controller, Service) 통과 확인
- [x] Postman을 통한 로컬 환경 API 엔드포인트 응답 테스트 완료

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
-Spring Security의 LockedException과 BadCredentialsException을 분기하여 처리했습니다. BANNED 유저 외 다른 실패 케이스에 영향 없는지 확인 부탁드립니다.!

## ✅ 체크 리스트
- [ ] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [ ] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [ ] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #