### PR TITLE
커뮤니티 비공개 게시글 식별 UI 추가 및 상세 페이지 헤더 노출 오류 수정

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/community/controller/PostController.java
+++ b/src/main/java/com/wanted/naeil/domain/community/controller/PostController.java
@@ -49,12 +49,13 @@ public class PostController {
 
         log.info("[게시글 목록] 조회 시작. category: {}, sortType: {}", category, sortType);
 
+        User loginUser = getLoginUser(authDetails);
         if (authDetails != null) {
             mv.addObject("user", authDetails.getLoginUserDTO());
         }
 
         PostCategory postCategory = PostCategory.valueOf(category.toUpperCase());
-        List<PostListResponse> posts = postService.getPostList(postCategory, sortType);
+        List<PostListResponse> posts = postService.getPostList(postCategory, sortType, loginUser);
 
         mv.addObject("posts", posts);
         mv.addObject("sortType", sortType);
@@ -93,6 +94,7 @@ public class PostController {
         mv.addObject("category", category);
         mv.addObject("isOwner", isOwner);
         mv.addObject("isAdmin", isAdmin);
+        mv.addObject("user", authDetails != null ? authDetails.getLoginUserDTO() : null);
         mv.addObject("loginUser", loginUser);
 
         PostCategory postCategory = PostCategory.valueOf(category.toUpperCase());

--- a/src/main/java/com/wanted/naeil/domain/community/dto/response/PostListResponse.java
+++ b/src/main/java/com/wanted/naeil/domain/community/dto/response/PostListResponse.java
@@ -18,6 +18,7 @@ public class PostListResponse {
     private long likeCount;
     private String courseTitle;
     private boolean isResolved;
+    public boolean isPublic;
 
     public static PostListResponse from(Post post, long likeCount) {
         return PostListResponse.builder()
@@ -29,6 +30,7 @@ public class PostListResponse {
                 .likeCount(likeCount)
                 .courseTitle(post.getCourse() != null ? post.getCourse().getTitle() : null)
                 .isResolved(post.isResolved())
+                .isPublic(post.isPublic())
                 .build();
     }
 }

--- a/src/main/java/com/wanted/naeil/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/community/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.wanted.naeil.domain.community.repository;
 import com.wanted.naeil.domain.community.entity.Post;
 import com.wanted.naeil.domain.community.entity.enums.PostCategory;
 import com.wanted.naeil.domain.course.entity.Course;
+import com.wanted.naeil.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,15 +13,21 @@ import java.util.Optional;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // 목록 조회 - 최신순 (기본)
+    // 1. 공개글 조회 (일반 유저용)
     List<Post> findByCategoryAndIsPublicTrueOrderByCreatedAtDesc(PostCategory category);
-
-    // 목록 조회 - 오래된순
     List<Post> findByCategoryAndIsPublicTrueOrderByCreatedAtAsc(PostCategory category);
-
-    // 목록 조회 - 조회순
     List<Post> findByCategoryAndIsPublicTrueOrderByViewCountDesc(PostCategory category);
 
-    // Q&A - 특정 강의 필터 + 최신순
+    // 2. 특정 유저의 글 조회 (작성자 본인용) - 비공개 포함
+    List<Post> findByCategoryAndUserOrderByCreatedAtDesc(PostCategory category, User user);
+    List<Post> findByCategoryAndUserOrderByCreatedAtAsc(PostCategory category, User user);
+    List<Post> findByCategoryAndUserOrderByViewCountDesc(PostCategory category, User user);
+
+    // 3. 카테고리 전체 조회 (관리자용) - 비공개 포함
+    List<Post> findByCategoryOrderByCreatedAtDesc(PostCategory category);
+    List<Post> findByCategoryOrderByCreatedAtAsc(PostCategory category);
+    List<Post> findByCategoryOrderByViewCountDesc(PostCategory category);
+
+    // 4. Q&A - 특정 강의 필터 + 최신순
     List<Post> findByCategoryAndCourseAndIsPublicTrueOrderByCreatedAtDesc(PostCategory category, Course course);
 }

--- a/src/main/java/com/wanted/naeil/domain/community/service/PostService.java
+++ b/src/main/java/com/wanted/naeil/domain/community/service/PostService.java
@@ -21,9 +21,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,19 +36,58 @@ public class PostService {
 
     // 글 목록 조회
     @Transactional(readOnly = true)
-    public List<PostListResponse> getPostList(PostCategory category, String sortType) {
-        List<Post> posts = switch (sortType) {
-            case "oldest"  -> postRepository.findByCategoryAndIsPublicTrueOrderByCreatedAtAsc(category);
-            case "popular" -> postRepository.findByCategoryAndIsPublicTrueOrderByViewCountDesc(category);
-            default        -> postRepository.findByCategoryAndIsPublicTrueOrderByCreatedAtDesc(category);
-        };
+    public List<PostListResponse> getPostList(PostCategory category, String sortType, User loginUser) {
+
+        List<Post> posts;
+
+        // A. 관리자: 모든 글 조회
+        if (loginUser != null && loginUser.getRole() == Role.ADMIN) {
+            posts = switch (sortType) {
+                case "oldest"  -> postRepository.findByCategoryOrderByCreatedAtAsc(category);
+                case "popular" -> postRepository.findByCategoryOrderByViewCountDesc(category);
+                default        -> postRepository.findByCategoryOrderByCreatedAtDesc(category);
+            };
+        }
+        // B. 일반 유저 및 비로그인
+        else {
+            // 1. 공개글을 가져오기
+            posts = switch (sortType) {
+                case "oldest"  -> postRepository.findByCategoryAndIsPublicTrueOrderByCreatedAtAsc(category);
+                case "popular" -> postRepository.findByCategoryAndIsPublicTrueOrderByViewCountDesc(category);
+                default        -> postRepository.findByCategoryAndIsPublicTrueOrderByCreatedAtDesc(category);
+            };
+
+            // 2. 로그인 상태라면 '내가 쓴 글(비공개 포함)'을 가져와서 합침
+            if (loginUser != null) {
+                List<Post> myPosts = switch (sortType) {
+                    case "oldest"  -> postRepository.findByCategoryAndUserOrderByCreatedAtAsc(category, loginUser);
+                    case "popular" -> postRepository.findByCategoryAndUserOrderByViewCountDesc(category, loginUser);
+                    default        -> postRepository.findByCategoryAndUserOrderByCreatedAtDesc(category, loginUser);
+                };
+
+                // 중복 제거 및 병합
+                Set<Post> combinedSet = new LinkedHashSet<>(posts);
+                combinedSet.addAll(myPosts);
+
+                posts = new ArrayList<>(combinedSet);
+
+                // 리스트 정렬 유지
+                sortPosts(posts, sortType);
+            }
+        }
 
         return posts.stream()
-                .map(post -> {
-                    long likeCount = likeRepository.countByPost(post);
-                    return PostListResponse.from(post, likeCount);
-                })
+                .map(post -> PostListResponse.from(post, likeRepository.countByPost(post)))
                 .collect(Collectors.toList());
+    }
+
+    // 정렬 형식을 맞추기 위한 헬퍼 메서드
+    private void sortPosts(List<Post> posts, String sortType) {
+        switch (sortType) {
+            case "oldest"  -> posts.sort(Comparator.comparing(Post::getCreatedAt));
+            case "popular" -> posts.sort(Comparator.comparing(Post::getViewCount).reversed());
+            default        -> posts.sort(Comparator.comparing(Post::getCreatedAt).reversed());
+        }
     }
 
     // 글 상세 조회
@@ -97,7 +134,7 @@ public class PostService {
                 .category(request.getCategory())
                 .title(request.getTitle())
                 .content(request.getContent())
-                .isPublic(request.getIsPublic() == null || request.getIsPublic())
+                .isPublic(request.getIsPublic() != null && request.getIsPublic())
                 .build();
 
         postRepository.save(post);
@@ -111,8 +148,8 @@ public class PostService {
 
         validateOwner(post, loginUser);
 
-        post.update(request.getTitle(), request.getContent(),
-                request.getIsPublic() != null ? request.getIsPublic() : post.isPublic());
+        boolean isPublicParam = (request.getIsPublic() != null && request.getIsPublic());
+        post.update(request.getTitle(), request.getContent(), isPublicParam);
     }
 
     // 글 삭제

--- a/src/main/resources/templates/community/QnADetail.html
+++ b/src/main/resources/templates/community/QnADetail.html
@@ -97,7 +97,14 @@
           </span>
         </div>
 
-        <h1 class="text-3xl font-black text-gray-900 mb-6" th:text="${post.title}">제목</h1>
+        <h1 class="text-3xl font-black text-gray-900 mb-6 flex items-center gap-3">
+          <span th:text="${post.title}">제목</span>
+          <span th:if="${!post.isPublic}"
+                class="inline-flex items-center gap-1.5 px-3 py-1 bg-gray-100 text-gray-500 rounded-lg text-sm font-bold border border-gray-200">
+    <i class="fa-solid fa-lock text-xs"></i>
+    비공개
+  </span>
+        </h1>
 
         <div class="flex items-center gap-3 mb-6">
           <span th:class="${post.isResolved} ? 'px-3 py-1 rounded-full text-sm font-bold bg-green-100 text-green-700' : 'px-3 py-1 rounded-full text-sm font-bold bg-gray-100 text-gray-600'"

--- a/src/main/resources/templates/community/QnAList.html
+++ b/src/main/resources/templates/community/QnAList.html
@@ -77,8 +77,11 @@
                       class="px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full text-xs font-bold border border-blue-200"
                       th:text="${post.courseTitle}">강의명</span>
 
-                <h3 class="text-xl font-bold text-gray-900 group-hover:text-blue-600 transition-colors"
-                    th:text="${post.title}">제목</h3>
+                <div class="flex items-center gap-2">
+                  <h3 class="text-xl font-bold text-gray-900 group-hover:text-blue-600 transition-colors"
+                      th:text="${post.title}">제목</h3>
+                  <i th:if="${!post.isPublic}" class="fa-solid fa-lock text-gray-400 text-sm"></i>
+                </div>
 
                 <span th:if="${post.isResolved}"
                       class="px-2 py-0.5 bg-green-100 text-green-700 rounded text-[11px] font-bold border border-green-200">해결됨</span>

--- a/src/main/resources/templates/community/freeBoardDetail.html
+++ b/src/main/resources/templates/community/freeBoardDetail.html
@@ -87,7 +87,14 @@
           </div>
         </div>
 
-        <h1 class="text-3xl font-black text-gray-900 mb-6" th:text="${post.title}">제목</h1>
+        <h1 class="text-3xl font-black text-gray-900 mb-6 flex items-center gap-3">
+          <span th:text="${post.title}">제목</span>
+          <span th:if="${!post.isPublic}"
+                class="inline-flex items-center gap-1.5 px-3 py-1 bg-gray-100 text-gray-500 rounded-lg text-sm font-bold border border-gray-200">
+    <i class="fa-solid fa-lock text-xs"></i>
+    비공개
+  </span>
+        </h1>
 
         <div class="bg-gray-100 rounded-2xl p-6 mb-6">
           <p class="text-gray-700 leading-relaxed whitespace-pre-wrap" th:text="${post.content}">내용</p>

--- a/src/main/resources/templates/community/freeBoardList.html
+++ b/src/main/resources/templates/community/freeBoardList.html
@@ -90,8 +90,10 @@
            class="block bg-white border-2 border-gray-200 rounded-2xl p-6 hover:shadow-xl hover:-translate-y-1 transition-all group">
           <div class="flex items-start justify-between">
             <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 group-hover:text-blue-600 transition-colors mb-3"
-                  th:text="${post.title}">제목</h3>
+              <h3 class="text-xl font-bold text-gray-900 group-hover:text-blue-600 transition-colors mb-3 flex items-center gap-2">
+                <span th:text="${post.title}">제목</span>
+                <i th:if="${!post.isPublic}" class="fa-solid fa-lock text-gray-400 text-sm" title="비공개"></i>
+              </h3>
               <div class="flex items-center gap-4">
                 <span class="text-sm text-gray-600 font-medium"
                       th:text="${post.nickname}">작성자</span>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)

게시글 비공개 식별 UI(자물쇠 아이콘/배지) 구현

상세 페이지 헤더 노출 오류 수정 및 관련 DTO 필드 보완

## 💡 어떤 기능인가요?

게시글의 공개/비공개 상태를 시각화하여 사용자 편의성을 높이고, 상세 페이지에서 게스트 헤더가 노출되던 버그를 수정하여 서비스 일관성을 확보한 작업입니다.

## ✨ 변경 사항 (Changes)

목록 페이지(QnAList, freeBoardList) 제목 옆 비공개 아이콘 추가

상세 페이지(QnADetail, freeBoardDetail) 제목 옆 비공개 상태 배지 추가

PostController 내 상세 조회 메서드에 헤더 연동용 user 객체 모델 추가

PostListResponse DTO에 isPublic 필드 추가하여 렌더링 에러 해결

## 📝 작업 상세 내용
[x] 기능 구현
[x] 버그 수정
[x] 리팩토링
[x] 테스트 완료

## 📋 테스트 내용 (Testing)

[x] JUnit 단위 테스트 (Controller, Service) 통과 확인

[x] 로컬 환경에서 권한별 자물쇠 노출 및 헤더 정상 출력 테스트 완료

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말

상세 페이지에서 유저 정보를 넘길 때 목록 페이지와 동일한 변수명(user)을 사용하도록 수정하여 헤더 파싱 문제를 해결했습니다.

## ✅ 체크 리스트

[x] 로컬 환경에서 빌드가 정상적으로 성공했나요?

[x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?

[x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)

Closes #238 