### PR TITLE
Feature ajs - 강의 전체 조회 페이징 기능 추가 및 성능 최적화

### DIFF
--- a/src/main/java/com/wanted/naeil/domain/course/controller/UserCourseController.java
+++ b/src/main/java/com/wanted/naeil/domain/course/controller/UserCourseController.java
@@ -9,6 +9,10 @@ import com.wanted.naeil.domain.user.repository.UserRepository;
 import com.wanted.naeil.global.auth.model.dto.AuthDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @Controller
@@ -35,17 +38,30 @@ public class UserCourseController {
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam(required = false) String category,
             @RequestParam(required = false) String keyword,
-            ModelAndView mv) {
+            @RequestParam(defaultValue = "latest") String sort,
+            @RequestParam(defaultValue = "0") int page,
+            ModelAndView mv
+    ) {
 
         log.info("[Course] 전체 코스 목록 페이지 조회 - category: {}, keyword: {}", category, keyword);
 
-        List<CourseListResponse> courses = courseService.getCourses(category, keyword);
+        int pageSize = 12;
+        int currentPage = Math.max(page, 0);
+
+        Pageable pageable = PageRequest.of(currentPage, pageSize);
+
+        Slice<CourseListResponse> coursePage = courseService
+                .getCourses(category, keyword, sort, pageable);
 
         if (authDetails != null) {
             mv.addObject("user", authDetails.getLoginUserDTO());
         }
 
-        mv.addObject("courses", courses);
+        mv.addObject("courses", coursePage.getContent());
+        mv.addObject("currentPage", currentPage);
+        mv.addObject("hasPrevious", coursePage.hasPrevious());
+        mv.addObject("hasNext", coursePage.hasNext());
+        mv.addObject("selectedSort", sort);
         mv.addObject("categories", categoryRepository.findAll());
         mv.addObject("selectedCategory", category);
         mv.addObject("keyword", keyword);

--- a/src/main/java/com/wanted/naeil/domain/course/entity/enums/CourseSortType.java
+++ b/src/main/java/com/wanted/naeil/domain/course/entity/enums/CourseSortType.java
@@ -1,0 +1,27 @@
+package com.wanted.naeil.domain.course.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseSortType {
+
+    LATEST("최신순"),
+    OLDEST("오래된순"),
+    POPULAR("인기순");
+
+    private final String description;
+
+    public static CourseSortType from(String value) {
+        if (value == null || value.isBlank()) {
+            return LATEST;
+        }
+
+        try {
+            return CourseSortType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return LATEST;
+        }
+    }
+}

--- a/src/main/java/com/wanted/naeil/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/wanted/naeil/domain/course/repository/CourseRepository.java
@@ -4,6 +4,8 @@ import com.wanted.naeil.domain.course.dto.response.CourseListResponse;
 import com.wanted.naeil.domain.course.entity.Category;
 import com.wanted.naeil.domain.course.entity.Course;
 import com.wanted.naeil.domain.course.entity.enums.CourseStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -108,23 +110,69 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
             @Param("status") CourseStatus status
     );
 
-    // 강의 검색 기능
+    // 강의 검색 기능 : 최신순
     @Query("select new com.wanted.naeil.domain.course.dto.response.CourseListResponse(" +
             "c.id, c.thumbnail, cat.name, c.title, c.description, u.name, " +
             "AVG(r.rating), COUNT(distinct e.id), c.price) " +
             "FROM Course c " +
             "JOIN c.category cat " +
             "JOIN c.instructor u " +
-            "LEFT join Review r ON r.course = c " +
+            "LEFT JOIN Review r ON r.course = c " +
             "LEFT JOIN Enrollment e ON e.course = c " +
             "WHERE c.status = :status " +
             "AND (:category IS NULL OR cat.name = :category) " +
             "AND (:keyword IS NULL OR (c.title LIKE %:keyword% OR c.description LIKE %:keyword% OR u.name LIKE %:keyword%)) " +
-            "GROUP BY c.id, cat.name, u.name, c.thumbnail, c.title, c.description, c.price")
-    List<CourseListResponse> searchCourseList(
+            "GROUP BY c.id, cat.name, u.name, c.thumbnail, c.title, c.description, c.price, c.createdAt " +
+            "ORDER BY c.createdAt DESC")
+    Slice<CourseListResponse> searchCourseListLatest(
             @Param("category") String category,
             @Param("keyword") String keyword,
-            @Param("status") CourseStatus status
+            @Param("status") CourseStatus status,
+            Pageable pageable
     );
+
+    // 오래된 순
+    @Query("select new com.wanted.naeil.domain.course.dto.response.CourseListResponse(" +
+            "c.id, c.thumbnail, cat.name, c.title, c.description, u.name, " +
+            "AVG(r.rating), COUNT(distinct e.id), c.price) " +
+            "FROM Course c " +
+            "JOIN c.category cat " +
+            "JOIN c.instructor u " +
+            "LEFT JOIN Review r ON r.course = c " +
+            "LEFT JOIN Enrollment e ON e.course = c " +
+            "WHERE c.status = :status " +
+            "AND (:category IS NULL OR cat.name = :category) " +
+            "AND (:keyword IS NULL OR (c.title LIKE %:keyword% OR c.description LIKE %:keyword% OR u.name LIKE %:keyword%)) " +
+            "GROUP BY c.id, cat.name, u.name, c.thumbnail, c.title, c.description, c.price, c.createdAt " +
+            "ORDER BY c.createdAt ASC")
+    Slice<CourseListResponse> searchCourseListOldest(
+            @Param("category") String category,
+            @Param("keyword") String keyword,
+            @Param("status") CourseStatus status,
+            Pageable pageable
+    );
+
+
+    // 인기 순
+    @Query("select new com.wanted.naeil.domain.course.dto.response.CourseListResponse(" +
+            "c.id, c.thumbnail, cat.name, c.title, c.description, u.name, " +
+            "AVG(r.rating), COUNT(distinct e.id), c.price) " +
+            "FROM Course c " +
+            "JOIN c.category cat " +
+            "JOIN c.instructor u " +
+            "LEFT JOIN Review r ON r.course = c " +
+            "LEFT JOIN Enrollment e ON e.course = c " +
+            "WHERE c.status = :status " +
+            "AND (:category IS NULL OR cat.name = :category) " +
+            "AND (:keyword IS NULL OR (c.title LIKE %:keyword% OR c.description LIKE %:keyword% OR u.name LIKE %:keyword%)) " +
+            "GROUP BY c.id, cat.name, u.name, c.thumbnail, c.title, c.description, c.price, c.createdAt " +
+            "ORDER BY COUNT(distinct e.id) DESC, c.createdAt DESC")
+    Slice<CourseListResponse> searchCourseListPopular(
+            @Param("category") String category,
+            @Param("keyword") String keyword,
+            @Param("status") CourseStatus status,
+            Pageable pageable
+    );
+
 
 }

--- a/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
+++ b/src/main/java/com/wanted/naeil/domain/course/service/CourseService.java
@@ -12,6 +12,7 @@ import com.wanted.naeil.domain.course.dto.request.CourseUpdateRequest;
 import com.wanted.naeil.domain.course.dto.response.*;
 import com.wanted.naeil.domain.course.entity.Category;
 import com.wanted.naeil.domain.course.entity.Course;
+import com.wanted.naeil.domain.course.entity.enums.CourseSortType;
 import com.wanted.naeil.domain.course.entity.enums.CourseStatus;
 import com.wanted.naeil.domain.course.repository.CategoryRepository;
 import com.wanted.naeil.domain.course.repository.CourseRepository;
@@ -24,6 +25,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -411,16 +414,47 @@ public class CourseService {
 
     // 검색기능
     @Transactional(readOnly = true)
-    public List<CourseListResponse> getCourses(String category, String keyword) {
+    public Slice<CourseListResponse> getCourses(
+            String category,
+            String keyword,
+            String sort,
+            Pageable pageable
+    ) {
         String normalizedCategory = (category == null || category.isBlank()) ? null : category;
         String normalizedKeyword = (keyword == null || keyword.isBlank()) ? null : keyword;
+        CourseSortType sortType = CourseSortType.from(sort);
 
-        return courseRepository.searchCourseList(
-                normalizedCategory,
-                normalizedKeyword,
-                CourseStatus.ACTIVE
-        );
+        // 전통적인 Switch 문 방식
+        switch (sortType) {
+            case LATEST:
+                return courseRepository.searchCourseListLatest(
+                        normalizedCategory,
+                        normalizedKeyword,
+                        CourseStatus.ACTIVE,
+                        pageable
+                );
+            case OLDEST:
+                return courseRepository.searchCourseListOldest(
+                        normalizedCategory,
+                        normalizedKeyword,
+                        CourseStatus.ACTIVE,
+                        pageable
+                );
+            case POPULAR:
+                return courseRepository.searchCourseListPopular(
+                        normalizedCategory,
+                        normalizedKeyword,
+                        CourseStatus.ACTIVE,
+                        pageable
+                );
+            default:
+                // Enum의 모든 케이스를 처리하더라도 정석적인 문법에서는
+                // 예외 상황에 대비한 default 혹은 throw 문이 필요합니다.
+                throw new IllegalArgumentException("지원하지 않는 정렬 타입입니다: " + sortType);
+        }
     }
+
+
 
 
     // ==== 내부 편의 메서드 ====

--- a/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
+++ b/src/main/java/com/wanted/naeil/domain/live/service/LiveLectureService.java
@@ -15,6 +15,7 @@ import com.wanted.naeil.domain.live.repository.LiveReservationRepository;
 import com.wanted.naeil.domain.user.entity.User;
 import com.wanted.naeil.domain.user.entity.enums.Role;
 import com.wanted.naeil.domain.user.repository.UserRepository;
+import com.wanted.naeil.global.aop.annotation.AuditLog;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -264,6 +265,7 @@ public class LiveLectureService {
     }
 
     // 실시간 강의 취소 기능 - 유저
+    @AuditLog(action = "LIVE_RESERVATION_CANCEL")
     @Transactional
     public void cancelLiveLectureReservation(Long userId, Long liveId) {
 

--- a/src/main/java/com/wanted/naeil/global/aop/AuditLogAspect.java
+++ b/src/main/java/com/wanted/naeil/global/aop/AuditLogAspect.java
@@ -1,0 +1,36 @@
+package com.wanted.naeil.global.aop;
+
+import com.wanted.naeil.global.aop.annotation.AuditLog;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Aspect
+@Component
+@Slf4j
+public class AuditLogAspect {
+
+    @AfterReturning("@annotation(auditLog)")
+    public void auditSuccess(JoinPoint joinPoint, AuditLog auditLog) {
+        log.info("[AUDIT_SUCCESS] action={}, method={}.{}, args={}",
+                auditLog.action(),
+                joinPoint.getSignature().getDeclaringTypeName(),
+                joinPoint.getSignature().getName(),
+                Arrays.toString(joinPoint.getArgs()));
+    }
+
+    @AfterThrowing(pointcut = "@annotation(auditLog)", throwing = "ex")
+    public void auditFailure(JoinPoint joinPoint, AuditLog auditLog, Exception ex) {
+        log.warn("[AUDIT_FAILURE] action={}, method={}.{}, args={}, reason={}",
+                auditLog.action(),
+                joinPoint.getSignature().getDeclaringTypeName(),
+                joinPoint.getSignature().getName(),
+                Arrays.toString(joinPoint.getArgs()),
+                ex.getMessage());
+    }
+}

--- a/src/main/java/com/wanted/naeil/global/aop/annotation/AuditLog.java
+++ b/src/main/java/com/wanted/naeil/global/aop/annotation/AuditLog.java
@@ -1,0 +1,13 @@
+package com.wanted.naeil.global.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuditLog {
+
+    String action();
+}

--- a/src/main/resources/templates/course/courseList.html
+++ b/src/main/resources/templates/course/courseList.html
@@ -7,10 +7,6 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
     <script src="https://unpkg.com/lucide@latest"></script>
-<!--    <style>-->
-<!--        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap');-->
-<!--        body { font-family: 'Inter', sans-serif; background-color: #f8fafc; }-->
-<!--    </style>-->
 </head>
 <body>
 <th:block th:if="${user == null or user.role == null}">
@@ -32,7 +28,8 @@
 <main class="max-w-7xl mx-auto px-6 py-12">
     <a th:href="@{/dashboard}"
        href="/dashboard"
-       class="inline-flex items-center gap-2 text-gray-500 hover:text-blue-600 transition-colors mb-6 group">        <i data-lucide="chevron-left" class="w-4 h-4"></i>
+       class="inline-flex items-center gap-2 text-gray-500 hover:text-blue-600 transition-colors mb-6 group">
+        <i data-lucide="chevron-left" class="w-4 h-4"></i>
         <span class="text-sm font-bold">이전으로</span>
     </a>
 
@@ -42,6 +39,12 @@
     </div>
 
     <form th:action="@{/course}" method="get" class="relative mb-8">
+        <input type="hidden" name="page" value="0">
+
+        <input type="hidden"
+               name="sort"
+               th:value="${selectedSort}">
+
         <input type="hidden"
                name="category"
                th:if="${selectedCategory != null and !#strings.isEmpty(selectedCategory)}"
@@ -59,45 +62,96 @@
         </button>
     </form>
 
+    <div class="flex items-center justify-between gap-4 mb-6">
+        <div class="flex items-center gap-3 overflow-x-auto no-scrollbar">
+            <a th:href="@{/course(sort=${selectedSort}, keyword=${keyword}, page=0)}"
+               th:class="${selectedCategory == null or #strings.isEmpty(selectedCategory)}
+               ? 'px-5 py-2.5 rounded-full bg-gray-900 text-white font-bold text-sm shadow-lg'
+               : 'px-5 py-2.5 rounded-full bg-white border-2 border-gray-100 text-gray-600 font-bold text-sm hover:border-blue-200 transition-all'">
+                전체
+            </a>
 
-    <div class="flex items-center gap-3 overflow-x-auto no-scrollbar">
-        <a th:href="@{/course}"
-           th:class="${selectedCategory == null or #strings.isEmpty(selectedCategory)}
-           ? 'px-5 py-2.5 rounded-full bg-gray-900 text-white font-bold text-sm shadow-lg'
-           : 'px-5 py-2.5 rounded-full bg-white border-2 border-gray-100 text-gray-600 font-bold text-sm hover:border-blue-200 transition-all'">
-            전체
-        </a>
+            <a th:each="category : ${categories}"
+               th:href="@{/course(category=${category.name}, keyword=${keyword}, sort=${selectedSort}, page=0)}"
+               th:text="${category.name}"
+               th:class="${selectedCategory != null and selectedCategory == category.name}
+               ? 'px-5 py-2.5 rounded-full bg-gray-900 text-white font-bold text-sm shadow-lg'
+               : 'px-5 py-2.5 rounded-full bg-white border-2 border-gray-100 text-gray-600 font-bold text-sm hover:border-blue-200 transition-all'">
+                Backend
+            </a>
+        </div>
 
-        <a th:each="category : ${categories}"
-           th:href="@{/course(category=${category.name})}"
-           th:text="${category.name}"
-           th:class="${selectedCategory != null and selectedCategory == category.name}
-           ? 'px-5 py-2.5 rounded-full bg-gray-900 text-white font-bold text-sm shadow-lg'
-           : 'px-5 py-2.5 rounded-full bg-white border-2 border-gray-100 text-gray-600 font-bold text-sm hover:border-blue-200 transition-all'">
-            Backend
-        </a>
+        <form th:action="@{/course}" method="get" class="flex-shrink-0">
+            <input type="hidden"
+                   name="category"
+                   th:if="${selectedCategory != null and !#strings.isEmpty(selectedCategory)}"
+                   th:value="${selectedCategory}">
+
+            <input type="hidden"
+                   name="keyword"
+                   th:if="${keyword != null and !#strings.isEmpty(keyword)}"
+                   th:value="${keyword}">
+
+            <input type="hidden" name="page" value="0">
+
+            <select name="sort"
+                    onchange="this.form.submit()"
+                    class="px-5 py-3 rounded-xl border-2 border-gray-100 bg-white text-gray-700 font-bold focus:border-blue-400 focus:outline-none">
+                <option value="latest"
+                        th:selected="${selectedSort == null or selectedSort == 'latest'}">
+                    최신순
+                </option>
+                <option value="oldest"
+                        th:selected="${selectedSort == 'oldest'}">
+                    오래된순
+                </option>
+                <option value="popular"
+                        th:selected="${selectedSort == 'popular'}">
+                    인기순
+                </option>
+            </select>
+        </form>
     </div>
 
-
     <p class="text-sm font-bold text-gray-500 mb-6">
-        <span id="courseCount" th:text="${courses.size()}" class="text-blue-600 text-lg">0</span>개의 강의
+        <span id="courseCount"
+              th:text="${courses.size()}"
+              class="text-blue-600 text-lg">0</span>개의 강의
     </p>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-
         <a th:each="course : ${courses}"
-             th:href="@{/course/{id}(id=${course.courseId})}"
-             class="group bg-white border-2 border-gray-100 rounded-2xl overflow-hidden hover:shadow-2xl hover:border-blue-200 transition-all duration-300">
+           th:href="@{/course/{id}(id=${course.courseId})}"
+           class="group bg-white border-2 border-gray-100 rounded-2xl overflow-hidden hover:shadow-2xl hover:border-blue-200 transition-all duration-300">
+
             <div class="aspect-video relative overflow-hidden">
-                <img th:src="${course.thumbnail}" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500">
+                <img th:src="${course.thumbnail}"
+                     th:alt="${course.title}"
+                     class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500">
+
                 <div class="absolute top-4 left-4">
-                    <span th:text="${course.category}" class="bg-blue-50 text-blue-600 text-[10px] font-black px-2 py-1 rounded-md uppercase tracking-wider border border-blue-100">카테고리</span>
+                    <span th:text="${course.category}"
+                          class="bg-blue-50 text-blue-600 text-[10px] font-black px-2 py-1 rounded-md uppercase tracking-wider border border-blue-100">
+                        카테고리
+                    </span>
                 </div>
             </div>
+
             <div class="p-6">
-                <h3 th:text="${course.title}" class="text-xl font-black text-gray-900 mb-2 line-clamp-1 group-hover:text-blue-600 transition-colors">강의 제목</h3>
-                <p th:text="${course.description}" class="text-gray-500 text-sm font-medium mb-4 line-clamp-2">강의 설명</p>
-                <p th:text="${course.instructorName}" class="text-sm font-bold text-gray-700 mb-4">강사명</p>
+                <h3 th:text="${course.title}"
+                    class="text-xl font-black text-gray-900 mb-2 line-clamp-1 group-hover:text-blue-600 transition-colors">
+                    강의 제목
+                </h3>
+
+                <p th:text="${course.description}"
+                   class="text-gray-500 text-sm font-medium mb-4 line-clamp-2">
+                    강의 설명
+                </p>
+
+                <p th:text="${course.instructorName}"
+                   class="text-sm font-bold text-gray-700 mb-4">
+                    강사명
+                </p>
 
                 <div class="flex items-center justify-between pt-4 border-t border-gray-50">
                     <div class="flex items-center gap-3">
@@ -105,21 +159,46 @@
                             <i data-lucide="star" class="w-4 h-4 text-yellow-400 fill-yellow-400"></i>
                             <span th:text="${course.rating}" class="text-sm font-black">0.0</span>
                         </div>
+
                         <div class="flex items-center gap-1 text-gray-400">
                             <i class="fa-solid fa-users text-gray-400 text-xs"></i>
-                            <span th:text="${#numbers.formatInteger(course.studentCount, 0, 'COMMA')}" class="text-sm font-bold">0</span>
+                            <span th:text="${#numbers.formatInteger(course.studentCount, 0, 'COMMA')}"
+                                  class="text-sm font-bold">0</span>
                         </div>
                     </div>
-                    <span th:text="|${#numbers.formatInteger(course.price, 3, 'COMMA')}|" class="text-lg font-black text-gray-900">₩0</span>
+
+                    <span th:text="|${#numbers.formatInteger(course.price, 3, 'COMMA')}|"
+                          class="text-lg font-black text-gray-900">
+                        0
+                    </span>
                 </div>
             </div>
         </a>
+    </div>
 
+    <div class="mt-10 flex items-center justify-center gap-3"
+         th:if="${hasPrevious or hasNext}">
+
+        <a th:if="${hasPrevious}"
+           th:href="@{/course(page=${currentPage - 1}, category=${selectedCategory}, keyword=${keyword}, sort=${selectedSort})}"
+           class="px-5 py-3 rounded-xl border-2 border-gray-200 bg-white text-gray-700 font-bold hover:border-blue-300 hover:text-blue-600 transition-all">
+            이전
+        </a>
+
+        <span class="px-5 py-3 rounded-xl bg-gray-900 text-white font-black"
+              th:text="${currentPage + 1}">
+            1
+        </span>
+
+        <a th:if="${hasNext}"
+           th:href="@{/course(page=${currentPage + 1}, category=${selectedCategory}, keyword=${keyword}, sort=${selectedSort})}"
+           class="px-5 py-3 rounded-xl border-2 border-gray-200 bg-white text-gray-700 font-bold hover:border-blue-300 hover:text-blue-600 transition-all">
+            다음
+        </a>
     </div>
 </main>
 
 <script>
-    // 아이콘 렌더링
     lucide.createIcons();
 </script>
 </body>


### PR DESCRIPTION
## 📌 PR 요약 (Summary)
- 강의 전체 조회 페이지에 페이징 기능 추가
- 전체 강의 목록 조회 시 한 번에 모든 데이터를 조회하지 않도록 개선하여 조회 성능 최적화

## 💡 어떤 기능인가요?
- 사용자가 전체 강의 목록을 조회할 때 페이지 단위로 강의를 조회할 수 있는 기능
- 강의 목록 조회 시 불필요한 전체 데이터 조회를 줄여 응답 속도를 개선하는 기능

## ✨ 변경 사항 (Changes)
- `GET /course` 요청에 `page` 파라미터 추가
- 강의 전체 조회 로직을 `List` 기반 전체 조회에서 `Slice` 기반 페이징 조회로 변경
- 강의 목록 조회 Repository 쿼리에 `Pageable` 적용
- 최신순 기준 정렬을 위한 `ORDER BY c.createdAt DESC` 추가
- 강의 전체 조회 화면에 이전/다음 페이지 이동 버튼 추가
- 검색 및 카테고리 필터 사용 시 페이지가 0번으로 초기화되도록 처리
- **최적화 전 : 252ms, 최적화 후 : 242ms 약 0.01초 감소**

## 📝 작업 상세 내용
- [x] 기능 구현
- [ ] 버그 수정
- [x] 리팩토링
- [x] 테스트 완료

## 📋 테스트 내용 (Testing)
- [x] 로컬 환경에서 강의 전체 조회 페이지 정상 렌더링 확인
- [x] `/course?page=0`, `/course?page=1` 페이지 이동 확인
- [x] 카테고리 필터 적용 후 페이징 동작 확인
- [x] 검색어 입력 후 페이징 동작 확인
- [x] AOP 성능 로그를 통해 전체 조회 로직 실행 시간 확인
- [x] `compileJava` 빌드 통과 확인

# 🚨 리뷰어 참고 사항 (Reviewer Notes)
## 💬 리뷰어에게 할 말
- 전체 페이지 수 계산이 필요하지 않아 `Page` 대신 `Slice`를 사용함
- `Slice` 사용으로 별도 count query를 줄이고, 다음 페이지 존재 여부 중심으로 처리함
- 추후 2차 성능 개선으로 인덱스 추가 또는 검색 조건별 쿼리 분리를 검토할 예정

## ✅ 체크 리스트
- [x] 로컬 환경에서 빌드가 정상적으로 성공했나요?
- [x] 코딩 컨벤션(네이밍, 들여쓰기 등)을 준수했나요?
- [x] 불필요한 파일이나 콘솔 로그(System.out.println 등)가 포함되지 않았나요?

## 📎 관련 이슈 (Related Issues)
### { Closes #이슈번호 } 형식으로 PR을 작성하면, 이 코드가 메인 브랜치에 병합될 때 해당 번호의 이슈가 자동으로 닫히게(Close) 됩니다.
- Closes #
